### PR TITLE
Swift 2 support

### DIFF
--- a/Promissum.podspec
+++ b/Promissum.podspec
@@ -38,7 +38,7 @@ Promissum really shines when used to combine asynchronous operations from differ
     ss.ios.deployment_target = '8.0'
     ss.source_files = "extensions/PromissumExtensions/CoreDataKit+Promise.swift"
     ss.dependency "Promissum/Core"
-    ss.dependency "CoreDataKit", "~> 0.7"
+    ss.dependency "CoreDataKit" # , "~> 0.7"
   end
 
   s.subspec "UIKit" do |ss|

--- a/Promissum.podspec
+++ b/Promissum.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Promissum"
-  s.version      = "0.2.4"
+  s.version      = "0.3.0"
   s.license      = "MIT"
 
   s.summary      = "A promises library written in Swift featuring combinators like map, flatMap, whenAll, whenAny."

--- a/Promissum.podspec
+++ b/Promissum.podspec
@@ -31,7 +31,7 @@ Promissum really shines when used to combine asynchronous operations from differ
   s.subspec "Alamofire" do |ss|
     ss.source_files = "extensions/PromissumExtensions/Alamofire+Promise.swift"
     ss.dependency "Promissum/Core"
-    ss.dependency "Alamofire", "~> 1.3"
+    ss.dependency "Alamofire" # , "~> 1.3"
   end
 
   s.subspec "CoreDataKit" do |ss|

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It has useful combinators for working with promises like; `whenAll` for doing so
 
 Promissum really shines when used to combine asynchronous operations from different libraries. There are currently some basic extensions to UIKit, Alamofire and CoreDataKit, and contributions for extensions to other libraries are very welcome.
 
-This library has an extensive set of regression test, and has been used for months in several high profile production apps at [Q42](http://q42.com/swift).
+This library has an extensive set of regression tests, and has been used for months in several high profile production apps at [Q42](http://q42.com/swift).
 
 Example
 -------
@@ -57,11 +57,10 @@ Installation
 ### CocoaPods
 
 [CocoaPods](http://cocoapods.org) is a dependency manager for Cocoa projects.
-
-CocoaPods 0.36 RC adds supports for Swift and embedded frameworks. You can install it with the following command:
+You can install it with the following command:
 
 ```bash
-$ gem install cocoapods --pre
+$ gem install cocoapods
 ```
 
 To integrate Promissum into your Xcode project using CocoaPods, specify it in your `Podfile`:
@@ -70,7 +69,7 @@ To integrate Promissum into your Xcode project using CocoaPods, specify it in yo
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
-pod 'Promissum', '~> 0.2.2'
+pod 'Promissum', '~> 0.2.4'
 ```
 
 Then, run the following command:
@@ -78,22 +77,6 @@ Then, run the following command:
 ```bash
 $ pod install
 ```
-
-(These installation instructions are based on the ones for Alamofire)
-
-
-### Using git submodules
-
-If, for some reason, using CocoaPods is not an option, Promissum can be added via a git submodule.
-There are five steps, which I've also demonstrated in a [screencast](https://www.youtube.com/watch?v=ow1ZE7pfBH8):
-
-1. Add Promissum as a submodule the terminal using the command: `git submodule add https://github.com/tomlokhorst/Promissum.git`
-2. Open the `Promissum/src` folder, and drag `Promissum.xcodeproj` into the file navigator of your app project.
-3. In Xcode, navigate to the target configuration window by clicking on the blue project icon, and selecting the application target under the "Targets" heading in the sidebar.
-4. In the tab bar at the top of that window, open the "Build Phases" panel.
-5. Click on the + button at the top left of the panel and select "New Copy Files Phase". Rename this new phase to "Copy Frameworks", set the "Destination" to "Frameworks", and add `Promissum.framework`.
-
-(These installation instructions are based on the ones for Alamofire)
 
 
 Releases

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ It has useful combinators for working with promises like; `whenAll` for doing so
 
 Promissum really shines when used to combine asynchronous operations from different libraries. There are currently some basic extensions to UIKit, Alamofire and CoreDataKit, and contributions for extensions to other libraries are very welcome.
 
-This library has an extensive set of regression tests, and has been used for months in several high profile production apps at [Q42](http://q42.com/swift).
+This library has an extensive set of regression tests, documentation, and has been used for months in several high profile production apps at [Q42](http://q42.com/swift).
+
 
 Example
 -------
@@ -51,6 +52,44 @@ Promissum does not support cancellation, because cancellation does not work well
 Although, if you're looking at adding cancellation to a _PromiseSource_, you could use the [swift-cancellationtoken](https://github.com/tomlokhorst/swift-cancellationtoken) library I wrote. This is orthogonal to promises, however.
 
 
+Combinators
+-----------
+
+Listed below are some of the methods and functions provided this library. More documentation is available inline.
+
+### Instance methods on Promise
+
+* `.map(transform: Value -> NewValue)`  
+  Returns a Promise containing the result of mapping a function over the promise value.
+
+* `.flatMap(transform: Value -> Promise<NewValue, Error>)`  
+  Returns the flattened result of mapping a function over the promise value.
+
+* `.mapError(transform: Error -> NewError)`  
+  Returns a Promise containing the result of mapping a function over the promise error.
+
+* `.flatMapError(transform: Error -> Promise<Value, NewError>)`  
+  Returns the flattened result of mapping a function over the promise error.
+
+
+### Functions for dealing with Promises
+
+* `flatten(promise: Promise<Promise<Value, Error>, Error>)`  
+  Flattens a nested Promise of Promise into a single Promise.
+
+* `whenBoth(promiseA: Promise<A, Error>, _ promiseB: Promise<B, Error>)`  
+  Creates a Promise that resolves when both arguments to `whenBoth` resolve.
+
+* `whenAll(promises: [Promise<Value, Error>])`  
+  Creates a Promise that resolves when all provided Promises resolve.
+
+* `whenEither(promise1: Promise<Value, Error>, _ promise2: Promise<Value, Error>)`  
+  Creates a Promise that resolves when either argument to resolves.
+
+* `whenAny(promises: [Promise<Value, Error>])`  
+  Creates a Promise that resolves when any of the argument Promises resolves.
+
+
 Installation
 ------------
 
@@ -69,7 +108,7 @@ To integrate Promissum into your Xcode project using CocoaPods, specify it in yo
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
-pod 'Promissum', '~> 0.2.4'
+pod 'Promissum', '~> 0.3.0'
 ```
 
 Then, run the following command:
@@ -82,6 +121,7 @@ $ pod install
 Releases
 --------
 
+ - **0.3.0** - 2015-xx-xx - Swift 2.0 support, added custom error types
  - 0.2.4 - 2015-05-31 - Fixed examples. Updated CoreDataKit+Promise
  - 0.2.3 - 2015-04-13 - Swift 1.2 support
  - 0.2.2 - 2015-03-01 - Mac OS X support
@@ -90,6 +130,7 @@ Releases
  - 0.1.1 - 2015-05-31 - `whenAnyFinalized` combinator added
  - **0.1.0** - 2015-01-27 - Initial public release
  - 0.0.0 - 2014-10-12 - Initial privat version for project at [Q42](http://q42.com)
+
 
 Licence & Credits
 -----------------

--- a/examples/FadeExample/Podfile
+++ b/examples/FadeExample/Podfile
@@ -3,6 +3,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 pod 'Alamofire', :git => 'https://github.com/Alamofire/Alamofire.git', :branch => 'swift-2.0'
+pod 'CoreDataKit', :git => 'https://github.com/tomlokhorst/CoreDataKit', :branch => 'feature/fixes'
 pod 'Promissum', :path => '../../'
 pod 'Promissum/Alamofire', :path => '../../'
 pod 'Promissum/CoreDataKit', :path => '../../'

--- a/examples/FadeExample/Podfile.lock
+++ b/examples/FadeExample/Podfile.lock
@@ -8,13 +8,14 @@ PODS:
     - Promissum/Core
   - Promissum/Core (0.2.4)
   - Promissum/CoreDataKit (0.2.4):
-    - CoreDataKit (~> 0.7)
+    - CoreDataKit
     - Promissum/Core
   - Promissum/UIKit (0.2.4):
     - Promissum/Core
 
 DEPENDENCIES:
   - Alamofire (from `https://github.com/Alamofire/Alamofire.git`, branch `swift-2.0`)
+  - CoreDataKit (from `https://github.com/tomlokhorst/CoreDataKit`, branch `feature/fixes`)
   - Promissum (from `../../`)
   - Promissum/Alamofire (from `../../`)
   - Promissum/CoreDataKit (from `../../`)
@@ -24,6 +25,9 @@ EXTERNAL SOURCES:
   Alamofire:
     :branch: swift-2.0
     :git: https://github.com/Alamofire/Alamofire.git
+  CoreDataKit:
+    :branch: feature/fixes
+    :git: https://github.com/tomlokhorst/CoreDataKit
   Promissum:
     :path: ../../
 
@@ -31,10 +35,13 @@ CHECKOUT OPTIONS:
   Alamofire:
     :commit: 0fd77fec2a33e237ab99069c36410eb7101126c6
     :git: https://github.com/Alamofire/Alamofire.git
+  CoreDataKit:
+    :commit: 7b48d18504fdceff2e31e5969e93ce01badb1d62
+    :git: https://github.com/tomlokhorst/CoreDataKit
 
 SPEC CHECKSUMS:
   Alamofire: 39dddb7d3725d1771b1d2f7099c8bd45bd83ffbb
   CoreDataKit: a7f97808cf0ad543748fb40db38b9f7702c40277
-  Promissum: bfda2ded9e7559dafac057d759aee0f13150cf23
+  Promissum: 4d972777312edac5031eb6c1d97bd23d49b1e3b6
 
 COCOAPODS: 0.38.2

--- a/examples/MacExample/MacExample/NSAnimationContext+Promise.swift
+++ b/examples/MacExample/MacExample/NSAnimationContext+Promise.swift
@@ -11,8 +11,8 @@ import Promissum
 
 extension NSAnimationContext {
 
-  public class func runAnimationGroupPromise(changes: (NSAnimationContext!) -> Void) -> Promise<Void> {
-    let source = PromiseSource<Void>()
+  public class func runAnimationGroupPromise(changes: (NSAnimationContext!) -> Void) -> Promise<Void, NoError> {
+    let source = PromiseSource<Void, NoError>()
 
     self.runAnimationGroup(changes, completionHandler: source.resolve)
 

--- a/examples/MacExample/MacExample/ViewController.swift
+++ b/examples/MacExample/MacExample/ViewController.swift
@@ -32,14 +32,17 @@ class ViewController: NSViewController {
     let url = "https://api.github.com/repos/tomlokhorst/Promissum"
 
     // Start loading the JSON
-    let jsonPromise = Alamofire.request(.GET, url).responseJSONPromise()
+    let jsonPromise = Alamofire.request(.GET, url)
+      .responseJSONPromise()
+      .mapErrorType()
 
     // Fade out the "load" button
     self.loadButton.enabled = false
     let fadeoutPromise = NSAnimationContext.runAnimationGroupPromise { context in
-      context.duration = 0.5
-      self.loadButton.animator().alphaValue = 0
-    }
+        context.duration = 0.5
+        self.loadButton.animator().alphaValue = 0
+      }
+      .mapErrorType()
 
     // When both fade out and JSON loading complete, continue on
     whenBoth(jsonPromise, promiseB: fadeoutPromise)
@@ -54,10 +57,10 @@ class ViewController: NSViewController {
           self.detailsView.animator().alphaValue = 1
         }
       }
-      .trap { e in
-        self.errorField.stringValue = e.localizedDescription
+      .trap { error in
+        self.errorField.stringValue = "\(error)"
         self.errorField.alphaValue = 1
-    }
+      }
   }
 }
 

--- a/extensions/Podfile
+++ b/extensions/Podfile
@@ -5,6 +5,6 @@ use_frameworks!
 link_with "PromissumExtensions", "PromissumExtensionsTests"
 
 pod 'Alamofire', :git => 'https://github.com/Alamofire/Alamofire.git', :branch => 'swift-2.0'
-pod 'CoreDataKit', '~> 0.7.0'
+pod 'CoreDataKit', :git => 'https://github.com/tomlokhorst/CoreDataKit', :branch => 'feature/custom-error-type'
 pod 'Promissum', :path => '../'
 

--- a/extensions/Podfile
+++ b/extensions/Podfile
@@ -5,6 +5,6 @@ use_frameworks!
 link_with "PromissumExtensions", "PromissumExtensionsTests"
 
 pod 'Alamofire', :git => 'https://github.com/Alamofire/Alamofire.git', :branch => 'swift-2.0'
-pod 'CoreDataKit', :git => 'https://github.com/tomlokhorst/CoreDataKit', :branch => 'feature/custom-error-type'
+pod 'CoreDataKit', :git => 'https://github.com/tomlokhorst/CoreDataKit', :branch => 'feature/fixes'
 # pod 'Promissum', :path => '../' # All Promissum source files are manually included in project
 

--- a/extensions/Podfile.lock
+++ b/extensions/Podfile.lock
@@ -4,14 +4,14 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (from `https://github.com/Alamofire/Alamofire.git`, branch `swift-2.0`)
-  - CoreDataKit (from `https://github.com/tomlokhorst/CoreDataKit`, branch `feature/custom-error-type`)
+  - CoreDataKit (from `https://github.com/tomlokhorst/CoreDataKit`, branch `feature/fixes`)
 
 EXTERNAL SOURCES:
   Alamofire:
     :branch: swift-2.0
     :git: https://github.com/Alamofire/Alamofire.git
   CoreDataKit:
-    :branch: feature/custom-error-type
+    :branch: feature/fixes
     :git: https://github.com/tomlokhorst/CoreDataKit
 
 CHECKOUT OPTIONS:
@@ -19,7 +19,7 @@ CHECKOUT OPTIONS:
     :commit: 0fd77fec2a33e237ab99069c36410eb7101126c6
     :git: https://github.com/Alamofire/Alamofire.git
   CoreDataKit:
-    :commit: 347c276bcdaeb26d958ce8cc514fe5b66b673832
+    :commit: 7b48d18504fdceff2e31e5969e93ce01badb1d62
     :git: https://github.com/tomlokhorst/CoreDataKit
 
 SPEC CHECKSUMS:

--- a/extensions/Podfile.lock
+++ b/extensions/Podfile.lock
@@ -1,19 +1,22 @@
 PODS:
   - Alamofire (1.3.0)
-  - CoreDataKit (0.7.0)
+  - CoreDataKit (0.6.1)
   - Promissum (0.2.4):
     - Promissum/Core (= 0.2.4)
   - Promissum/Core (0.2.4)
 
 DEPENDENCIES:
   - Alamofire (from `https://github.com/Alamofire/Alamofire.git`, branch `swift-2.0`)
-  - CoreDataKit (~> 0.7.0)
+  - CoreDataKit (from `https://github.com/tomlokhorst/CoreDataKit`, branch `feature/custom-error-type`)
   - Promissum (from `../`)
 
 EXTERNAL SOURCES:
   Alamofire:
     :branch: swift-2.0
     :git: https://github.com/Alamofire/Alamofire.git
+  CoreDataKit:
+    :branch: feature/custom-error-type
+    :git: https://github.com/tomlokhorst/CoreDataKit
   Promissum:
     :path: ../
 
@@ -21,10 +24,13 @@ CHECKOUT OPTIONS:
   Alamofire:
     :commit: 1f2f39114412ed9bda242b0199db56c1296f8159
     :git: https://github.com/Alamofire/Alamofire.git
+  CoreDataKit:
+    :commit: 8694001be9dfbce5eb82e7a231a52e14d61eb3ae
+    :git: https://github.com/tomlokhorst/CoreDataKit
 
 SPEC CHECKSUMS:
   Alamofire: e57db85401895fda01783b3b9bda5b32d9f347ff
-  CoreDataKit: a7f97808cf0ad543748fb40db38b9f7702c40277
+  CoreDataKit: 53b886eb7de3279082c88ff440c445f89796e8c5
   Promissum: 17bf96fb317b1274380aabb960f0c44c023cc4f0
 
 COCOAPODS: 0.38.2

--- a/extensions/PromissumExtensions/Alamofire+Promise.swift
+++ b/extensions/PromissumExtensions/Alamofire+Promise.swift
@@ -10,7 +10,7 @@ import Foundation
 import Alamofire
 
 
-public enum AlamofirePromiseError {
+public enum AlamofirePromiseError : ErrorType {
   case JsonDecodeError
   case HttpNotFound(result: Alamofire.Result<AnyObject>)
   case HttpError(status: Int, result: Alamofire.Result<AnyObject>?)

--- a/extensions/PromissumExtensions/Alamofire+Promise.swift
+++ b/extensions/PromissumExtensions/Alamofire+Promise.swift
@@ -10,14 +10,6 @@ import Foundation
 import Alamofire
 import Promissum
 
-public let AlamofirePromiseErrorDomain = "com.nonstrict.promissum.alamofire"
-
-public let AlamofirePromiseRequestKey = "request"
-public let AlamofirePromiseResponseKey = "response"
-public let AlamofirePromiseDataKey = "data"
-public let AlamofirePromiseErrorKey = "error"
-
-public typealias AlamofireCompletion = (NSHTTPURLResponse?, AnyObject?, NSError?)
 
 public enum AlamofirePromiseError {
   case NoResponseAvailable
@@ -26,14 +18,6 @@ public enum AlamofirePromiseError {
   case HttpNotFound(data: AnyObject?)
   case HttpError(status: Int, data: AnyObject?)
   case UnknownError(error: NSError)
-}
-
-public enum AlamofirePromiseErrorCode : Int {
-  case UnknownError = 1
-  case HttpNotFound
-  case HttpError
-  case JsonDecodeError
-  case NoResponseAvailable
 }
 
 extension Request {

--- a/extensions/PromissumExtensions/CoreDataKit+Promise.swift
+++ b/extensions/PromissumExtensions/CoreDataKit+Promise.swift
@@ -13,20 +13,20 @@ import Promissum
 
 
 extension CDK {
-  public class func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction, NSError> {
+  public class func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction, CoreDataKitError> {
     return sharedStack!.performBlockOnBackgroundContextPromise(block)
   }
 }
 
 extension CoreDataStack {
-  public func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction, NSError> {
+  public func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction, CoreDataKitError> {
     return backgroundContext.performBlockPromise(block)
   }
 }
 
 extension NSManagedObjectContext {
-  public func performBlockPromise(block: PerformBlock) -> Promise<CommitAction, NSError> {
-    let promiseSource = PromiseSource<CommitAction, NSError>()
+  public func performBlockPromise(block: PerformBlock) -> Promise<CommitAction, CoreDataKitError> {
+    let promiseSource = PromiseSource<CommitAction, CoreDataKitError>()
 
     performBlock(block) { result in
       dispatch_async(dispatch_get_main_queue()) {
@@ -34,11 +34,11 @@ extension NSManagedObjectContext {
           let action = try result()
           promiseSource.resolve(action)
         }
-        catch let error as NSError {
-          promiseSource.reject(error)
+        catch let error as CoreDataKitError {
+            promiseSource.reject(error)
         }
-        catch {
-          fatalError("Should never happen")
+        catch let error {
+          promiseSource.reject(CoreDataKitError.UnknownError(description: "\(error)"))
         }
       }
     }

--- a/extensions/PromissumExtensions/CoreDataKit+Promise.swift
+++ b/extensions/PromissumExtensions/CoreDataKit+Promise.swift
@@ -13,7 +13,7 @@ import enum CoreDataKit.Result
 import Promissum
 
 extension Result {
-  func toPromise() -> Promise<T> {
+  func toPromise() -> Promise<T, NSError> {
     switch self {
     case let .Success(boxed):
       return Promise(value: boxed.value)
@@ -25,20 +25,20 @@ extension Result {
 }
 
 extension CDK {
-  public class func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction> {
+  public class func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction, NSError> {
     return sharedStack!.performBlockOnBackgroundContextPromise(block)
   }
 }
 
 extension CoreDataStack {
-  public func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction> {
+  public func performBlockOnBackgroundContextPromise(block: PerformBlock) -> Promise<CommitAction, NSError> {
     return rootContext.performBlockPromise(block)
   }
 }
 
 extension NSManagedObjectContext {
-  public func performBlockPromise(block: PerformBlock) -> Promise<CommitAction> {
-    let promiseSource = PromiseSource<CommitAction>()
+  public func performBlockPromise(block: PerformBlock) -> Promise<CommitAction, NSError> {
+    let promiseSource = PromiseSource<CommitAction, NSError>()
 
     performBlock(block) { result in
       dispatch_async(dispatch_get_main_queue()) {

--- a/extensions/PromissumExtensions/TinyNetworking+Promise.swift
+++ b/extensions/PromissumExtensions/TinyNetworking+Promise.swift
@@ -9,26 +9,12 @@
 import Foundation
 import Promissum
 
-public let TinyNetworkingPromiseErrorDomain = "com.nonstrict.promissum.tiny-networking"
+public typealias TinyNetworkingError = (reason: Reason, data: NSData?)
 
-public let TinyNetworkingPromiseReasonKey = "reason"
-public let TinyNetworkingPromiseDataKey = "data"
+public func apiRequestPromise<A>(modifyRequest: NSMutableURLRequest -> (), baseURL: NSURL, resource: Resource<A>) -> Promise<A, TinyNetworkingError> {
+  let source = PromiseSource<A, TinyNetworkingError>()
 
-public func apiRequestPromise<A>(modifyRequest: NSMutableURLRequest -> (), baseURL: NSURL, resource: Resource<A>) -> Promise<A> {
-  let source = PromiseSource<A>()
-
-  func onFailure(reason: Reason, data: NSData?) {
-    var userInfo: [NSObject: AnyObject] = [
-      TinyNetworkingPromiseReasonKey: Box(reason),
-    ]
-    if let data = data {
-      userInfo[TinyNetworkingPromiseDataKey] = data
-    }
-
-    source.reject(NSError(domain: TinyNetworkingPromiseErrorDomain, code: -1, userInfo: userInfo))
-  }
-
-  apiRequest(modifyRequest, baseURL, resource, onFailure, source.resolve)
+  apiRequest(modifyRequest, baseURL, resource, source.reject, source.resolve)
 
   return source.promise
 }

--- a/extensions/PromissumExtensions/UIKit+Promise.swift
+++ b/extensions/PromissumExtensions/UIKit+Promise.swift
@@ -10,48 +10,48 @@ import Promissum
 import UIKit
 
 extension UIView {
-  public class func animatePromise(# duration: NSTimeInterval, animations: () -> Void) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public class func animatePromise(# duration: NSTimeInterval, animations: () -> Void) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.animateWithDuration(duration, animations: animations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func animatePromise(# duration: NSTimeInterval, delay: NSTimeInterval, options: UIViewAnimationOptions, animations: () -> Void) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public class func animatePromise(# duration: NSTimeInterval, delay: NSTimeInterval, options: UIViewAnimationOptions, animations: () -> Void) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.animateWithDuration(duration, delay: delay, options: options, animations: animations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func transitionPromise(# view: UIView, duration: NSTimeInterval, options: UIViewAnimationOptions, animations: () -> Void) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public class func transitionPromise(# view: UIView, duration: NSTimeInterval, options: UIViewAnimationOptions, animations: () -> Void) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.transitionWithView(view, duration: duration, options: options, animations: animations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func transitionPromise(# fromView: UIView, toView: UIView, duration: NSTimeInterval, options: UIViewAnimationOptions) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public class func transitionPromise(# fromView: UIView, toView: UIView, duration: NSTimeInterval, options: UIViewAnimationOptions) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.transitionFromView(fromView, toView: toView, duration: duration, options: options, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func performSystemAnimationPromise(animation: UISystemAnimation, onViews views: [AnyObject], options: UIViewAnimationOptions, animations parallelAnimations: (() -> Void)?) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public class func performSystemAnimationPromise(animation: UISystemAnimation, onViews views: [AnyObject], options: UIViewAnimationOptions, animations parallelAnimations: (() -> Void)?) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.performSystemAnimation(animation, onViews: views, options: options, animations: parallelAnimations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func animateKeyframesPromise(# duration: NSTimeInterval, delay: NSTimeInterval, options: UIViewKeyframeAnimationOptions, animations: () -> Void) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public class func animateKeyframesPromise(# duration: NSTimeInterval, delay: NSTimeInterval, options: UIViewKeyframeAnimationOptions, animations: () -> Void) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.animateKeyframesWithDuration(duration, delay: delay, options: options, animations: animations, completion: source.resolve)
 
@@ -60,24 +60,24 @@ extension UIView {
 }
 
 extension UIViewController {
-  public func presentViewControllerPromise(viewControllerToPresent: UIViewController, animated flag: Bool) -> Promise<Void> {
-    let source = PromiseSource<Void>()
+  public func presentViewControllerPromise(viewControllerToPresent: UIViewController, animated flag: Bool) -> Promise<Void, NoError> {
+    let source = PromiseSource<Void, NoError>()
 
     self.presentViewController(viewControllerToPresent, animated: flag, completion: source.resolve)
 
     return source.promise
   }
 
-  public func dismissViewControllerPromise(animated flag: Bool) -> Promise<Void> {
-    let source = PromiseSource<Void>()
+  public func dismissViewControllerPromise(animated flag: Bool) -> Promise<Void, NoError> {
+    let source = PromiseSource<Void, NoError>()
 
     self.dismissViewControllerAnimated(flag, completion: source.resolve)
 
     return source.promise
   }
 
-  public func transitionPromise(# fromViewController: UIViewController, toViewController: UIViewController, duration: NSTimeInterval, options: UIViewAnimationOptions, animations: (() -> Void)?) -> Promise<Bool> {
-    let source = PromiseSource<Bool>()
+  public func transitionPromise(# fromViewController: UIViewController, toViewController: UIViewController, duration: NSTimeInterval, options: UIViewAnimationOptions, animations: (() -> Void)?) -> Promise<Bool, NoError> {
+    let source = PromiseSource<Bool, NoError>()
 
     self.transitionFromViewController(fromViewController, toViewController: toViewController, duration: duration, options: options, animations: animations, completion: source.resolve)
 
@@ -99,8 +99,8 @@ extension UIAlertView {
     }
   }
 
-  public func showPromise() -> Promise<Int> {
-    let source = PromiseSource<Int>()
+  public func showPromise() -> Promise<Int, NoError> {
+    let source = PromiseSource<Int, NoError>()
     let originalDelegate = self.delegate as? UIAlertViewDelegate
 
     self.delegate = AlertViewDelegate(source: source, alertView: self, originalDelegate: originalDelegate)
@@ -110,11 +110,11 @@ extension UIAlertView {
   }
 
   internal class AlertViewDelegate: NSObject, UIAlertViewDelegate {
-    let source: PromiseSource<Int>
+    let source: PromiseSource<Int, NoError>
     let alertView: UIAlertView
     let originalDelegate: UIAlertViewDelegate?
 
-    init(source: PromiseSource<Int>, alertView: UIAlertView, originalDelegate: UIAlertViewDelegate?) {
+    init(source: PromiseSource<Int, NoError>, alertView: UIAlertView, originalDelegate: UIAlertViewDelegate?) {
       self.source = source
       self.alertView = alertView
       self.originalDelegate = originalDelegate
@@ -169,8 +169,8 @@ extension UIActionSheet {
     }
   }
 
-  public func showInViewPromise(view: UIView!) -> Promise<Int> {
-    let source = PromiseSource<Int>()
+  public func showInViewPromise(view: UIView!) -> Promise<Int, NoError> {
+    let source = PromiseSource<Int, NoError>()
     let originalDelegate = self.delegate
 
     self.delegate = ActionSheetDelegate(source: source, actionSheet: self, originalDelegate: originalDelegate)
@@ -180,11 +180,11 @@ extension UIActionSheet {
   }
 
   internal class ActionSheetDelegate: NSObject, UIActionSheetDelegate {
-    let source: PromiseSource<Int>
+    let source: PromiseSource<Int, NoError>
     let actionSheet: UIActionSheet
     let originalDelegate: UIActionSheetDelegate?
 
-    init(source: PromiseSource<Int>, actionSheet: UIActionSheet, originalDelegate: UIActionSheetDelegate?) {
+    init(source: PromiseSource<Int, NoError>, actionSheet: UIActionSheet, originalDelegate: UIActionSheetDelegate?) {
       self.source = source
       self.actionSheet = actionSheet
       self.originalDelegate = originalDelegate

--- a/extensions/PromissumExtensions/UIKit+Promise.swift
+++ b/extensions/PromissumExtensions/UIKit+Promise.swift
@@ -92,7 +92,7 @@ let associationPolicy = objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC
 extension UIAlertView {
   var strongDelegate: AlertViewDelegate? {
     get {
-      return (objc_getAssociatedObject(self, &associatedObjectHandle) as! AlertViewDelegate)
+      return (objc_getAssociatedObject(self, &associatedObjectHandle) as? AlertViewDelegate)
     }
     set {
       objc_setAssociatedObject(self, &associatedObjectHandle, newValue, associationPolicy)
@@ -128,8 +128,6 @@ extension UIAlertView {
       originalDelegate?.alertView?(alertView, clickedButtonAtIndex: buttonIndex)
 
       source.resolve(buttonIndex)
-
-      self.alertView.strongDelegate = nil
     }
 
     func alertViewCancel(alertView: UIAlertView) {
@@ -150,6 +148,7 @@ extension UIAlertView {
 
     func alertView(alertView: UIAlertView, didDismissWithButtonIndex buttonIndex: Int) {
       originalDelegate?.alertView?(alertView, didDismissWithButtonIndex: buttonIndex)
+      self.alertView.strongDelegate = nil
     }
 
     func alertViewShouldEnableFirstOtherButton(alertView: UIAlertView) -> Bool {

--- a/extensions/PromissumExtensions/UIKit+Promise.swift
+++ b/extensions/PromissumExtensions/UIKit+Promise.swift
@@ -161,7 +161,7 @@ extension UIAlertView {
 extension UIActionSheet {
   var strongDelegate: ActionSheetDelegate? {
     get {
-      return (objc_getAssociatedObject(self, &associatedObjectHandle) as! ActionSheetDelegate)
+      return (objc_getAssociatedObject(self, &associatedObjectHandle) as? ActionSheetDelegate)
     }
     set {
       objc_setAssociatedObject(self, &associatedObjectHandle, newValue, associationPolicy)
@@ -197,8 +197,6 @@ extension UIActionSheet {
       originalDelegate?.actionSheet?(actionSheet, clickedButtonAtIndex: buttonIndex)
 
       source.resolve(buttonIndex)
-
-      self.actionSheet.strongDelegate = nil
     }
 
     func actionSheetCancel(actionSheet: UIActionSheet) {
@@ -219,6 +217,7 @@ extension UIActionSheet {
 
     func actionSheet(actionSheet: UIActionSheet, didDismissWithButtonIndex buttonIndex: Int) {
       originalDelegate?.actionSheet?(actionSheet, didDismissWithButtonIndex: buttonIndex)
+      self.actionSheet.strongDelegate = nil
     }
   }
 }

--- a/extensions/PromissumExtensionsTests/TinyNetworkingPromiseTests.swift
+++ b/extensions/PromissumExtensionsTests/TinyNetworkingPromiseTests.swift
@@ -32,13 +32,7 @@ class TinyNetworkingPromiseTests: XCTestCase {
         }
       }
       .catch { e in
-        if e.domain == TinyNetworkingPromiseErrorDomain {
-          if let reason = e.userInfo?[TinyNetworkingPromiseReasonKey] as? Box<Reason> {
-            println(reason.unbox)
-            return
-          }
-        }
-        println(e)
+        println(e.reason)
       }
 
     // Wait for 1 second for the request to finish

--- a/src/Promissum.xcodeproj/project.pbxproj
+++ b/src/Promissum.xcodeproj/project.pbxproj
@@ -37,7 +37,7 @@
 
 /* Begin PBXFileReference section */
 		E20506CE1A1A9C0E00A9644B /* Promise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
-		E20506CF1A1A9C0E00A9644B /* Combinators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Combinators.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		E20506CF1A1A9C0E00A9644B /* Combinators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Combinators.swift; sourceTree = "<group>"; };
 		E20506D11A1A9C0E00A9644B /* PromiseSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseSource.swift; sourceTree = "<group>"; };
 		E20506D21A1A9C0E00A9644B /* State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
 		E21860E81A1A9BB3005B6047 /* Promissum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Promissum.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/src/Promissum/Combinators.swift
+++ b/src/Promissum/Combinators.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public func flatten<T>(promise: Promise<Promise<T>>) -> Promise<T> {
-  let source = PromiseSource<T>()
+public func flatten<Value, Error>(promise: Promise<Promise<Value, Error>, Error>) -> Promise<Value, Error> {
+  let source = PromiseSource<Value, Error>()
 
   promise
     .catch(source.reject)
@@ -21,12 +21,12 @@ public func flatten<T>(promise: Promise<Promise<T>>) -> Promise<T> {
   return source.promise
 }
 
-public func whenBoth<A, B>(promiseA: Promise<A>, promiseB: Promise<B>) -> Promise<(A, B)> {
+public func whenBoth<A, B, Error>(promiseA: Promise<A, Error>, promiseB: Promise<B, Error>) -> Promise<(A, B), Error> {
   return promiseA.flatMap { valueA in promiseB.map { valueB in (valueA, valueB) } }
 }
 
-public func whenAll<T>(promises: [Promise<T>]) -> Promise<[T]> {
-  let source = PromiseSource<[T]>()
+public func whenAll<Value, Error>(promises: [Promise<Value, Error>]) -> Promise<[Value], Error> {
+  let source = PromiseSource<[Value], Error>()
   var results = promises.map { $0.value() }
   var remaining = promises.count
 
@@ -55,18 +55,13 @@ public func whenAll<T>(promises: [Promise<T>]) -> Promise<[T]> {
   return source.promise
 }
 
-public func whenEither<T>(promise1: Promise<T>, promise2: Promise<T>) -> Promise<T> {
+public func whenEither<Value, Error>(promise1: Promise<Value, Error>, promise2: Promise<Value, Error>) -> Promise<Value, Error> {
   return whenAny([promise1, promise2])
 }
 
-public func whenAny<T>(promises: [Promise<T>]) -> Promise<T> {
-  let source = PromiseSource<T>()
+public func whenAny<Value, Error>(promises: [Promise<Value, Error>]) -> Promise<Value, Error> {
+  let source = PromiseSource<Value, Error>()
   var remaining = promises.count
-
-  if remaining == 0 {
-    let userInfo = [ NSLocalizedDescriptionKey: "whenAny: empty array of promises provided" ]
-    source.reject(NSError(domain: PromissumErrorDomain, code: 0, userInfo: userInfo))
-  }
 
   for promise in promises {
 
@@ -88,8 +83,8 @@ public func whenAny<T>(promises: [Promise<T>]) -> Promise<T> {
   return source.promise
 }
 
-public func whenAllFinalized<T>(promises: [Promise<T>]) -> Promise<Void> {
-  let source = PromiseSource<Void>()
+public func whenAllFinalized<Value, Error>(promises: [Promise<Value, Error>]) -> Promise<Void, NoError> {
+  let source = PromiseSource<Void, NoError>()
   var remaining = promises.count
 
   if remaining == 0 {
@@ -111,14 +106,9 @@ public func whenAllFinalized<T>(promises: [Promise<T>]) -> Promise<Void> {
   return source.promise
 }
 
-public func whenAnyFinalized<T>(promises: [Promise<T>]) -> Promise<Void> {
-  let source = PromiseSource<Void>()
+public func whenAnyFinalized<Value, Error>(promises: [Promise<Value, Error>]) -> Promise<Void, NoError> {
+  let source = PromiseSource<Void, NoError>()
   var remaining = promises.count
-
-  if remaining == 0 {
-    let userInfo = [ NSLocalizedDescriptionKey: "whenAnyFinalized: empty array of promises provided" ]
-    source.reject(NSError(domain: PromissumErrorDomain, code: 0, userInfo: userInfo))
-  }
 
   for promise in promises {
 
@@ -132,7 +122,7 @@ public func whenAnyFinalized<T>(promises: [Promise<T>]) -> Promise<Void> {
 }
 
 extension Promise {
-  public func void() -> Promise<Void> {
+  public func void() -> Promise<Void, Error> {
     return self.map { _ in }
   }
 }

--- a/src/Promissum/Combinators.swift
+++ b/src/Promissum/Combinators.swift
@@ -125,3 +125,9 @@ extension Promise {
     return self.map { _ in }
   }
 }
+
+extension Promise where Error : ErrorType {
+  public func mapErrorType() -> Promise<Value, ErrorType> {
+    return self.mapError { $0 }
+  }
+}

--- a/src/Promissum/Delay+Promise.swift
+++ b/src/Promissum/Delay+Promise.swift
@@ -14,8 +14,8 @@ public func delay(seconds: NSTimeInterval, queue: dispatch_queue_t! = dispatch_g
   dispatch_after(when, queue, block)
 }
 
-public func delayPromise<T>(seconds: NSTimeInterval, value: T, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<T> {
-  let source = PromiseSource<T>()
+public func delayPromise<Value, Error>(seconds: NSTimeInterval, value: Value, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Value, Error> {
+  let source = PromiseSource<Value, Error>()
 
   delay(seconds, queue: queue) {
     source.resolve(value)
@@ -24,8 +24,8 @@ public func delayPromise<T>(seconds: NSTimeInterval, value: T, queue: dispatch_q
   return source.promise
 }
 
-public func delayErrorPromise<T>(seconds: NSTimeInterval, error: NSError, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<T> {
-  let source = PromiseSource<T>()
+public func delayErrorPromise<Value, Error>(seconds: NSTimeInterval, error: Error, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Value, Error> {
+  let source = PromiseSource<Value, Error>()
 
   delay(seconds, queue: queue) {
     source.reject(error)
@@ -34,14 +34,14 @@ public func delayErrorPromise<T>(seconds: NSTimeInterval, error: NSError, queue:
   return source.promise
 }
 
-public func delayPromise(seconds: NSTimeInterval, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Void> {
+public func delayPromise<Error>(seconds: NSTimeInterval, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Void, Error> {
   return delayPromise(seconds, (), queue: queue)
 }
 
-public func delay<T>(seconds: NSTimeInterval)(value: T) -> Promise<T> {
+public func delay<Value, Error>(seconds: NSTimeInterval)(value: Value) -> Promise<Value, Error> {
   return delayPromise(seconds).map { value }
 }
 
-public func delay<T>(seconds: NSTimeInterval)(error: NSError) -> Promise<T> {
+public func delay<Value, Error>(seconds: NSTimeInterval)(error: Error) -> Promise<Value, Error> {
   return delayPromise(seconds).flatMap { Promise(error: error) }
 }

--- a/src/Promissum/Delay+Promise.swift
+++ b/src/Promissum/Delay+Promise.swift
@@ -8,12 +8,14 @@
 
 import Foundation
 
+/// Wrapper around `dispatch_after`, with a seconds parameter.
 public func delay(seconds: NSTimeInterval, queue: dispatch_queue_t! = dispatch_get_main_queue(), block: dispatch_block_t!) {
   let when = dispatch_time(DISPATCH_TIME_NOW, Int64(seconds * Double(NSEC_PER_SEC)))
 
   dispatch_after(when, queue, block)
 }
 
+/// Create a Promise that resolves with the specified value after the specified number of seconds.
 public func delayPromise<Value, Error>(seconds: NSTimeInterval, value: Value, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Value, Error> {
   let source = PromiseSource<Value, Error>()
 
@@ -24,6 +26,7 @@ public func delayPromise<Value, Error>(seconds: NSTimeInterval, value: Value, qu
   return source.promise
 }
 
+/// Create a Promise that rejects with the specified error after the specified number of seconds.
 public func delayErrorPromise<Value, Error>(seconds: NSTimeInterval, error: Error, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Value, Error> {
   let source = PromiseSource<Value, Error>()
 
@@ -34,14 +37,21 @@ public func delayErrorPromise<Value, Error>(seconds: NSTimeInterval, error: Erro
   return source.promise
 }
 
+/// Create a Promise that resolves after the specified number of seconds.
 public func delayPromise<Error>(seconds: NSTimeInterval, queue: dispatch_queue_t! = dispatch_get_main_queue()) -> Promise<Void, Error> {
   return delayPromise(seconds, value: (), queue: queue)
 }
 
-public func delay<Value, Error>(seconds: NSTimeInterval)(_ value: Value) -> Promise<Value, Error> {
-  return delayPromise(seconds).map { value }
-}
+extension Promise {
 
-public func delay<Value, Error>(seconds: NSTimeInterval)(_ error: Error) -> Promise<Value, Error> {
-  return delayPromise(seconds).flatMap { Promise(error: error) }
+  /// Delays the resolve or reject of this Promise by the specified number of seconds.
+  public func delay(seconds: NSTimeInterval) -> Promise<Value, Error> {
+    return self
+      .flatMap { value in
+        return delayPromise(seconds).map { value }
+      }
+      .flatMapError { error in
+        return delayPromise(seconds).flatMap { Promise(error: error) }
+      }
+  }
 }

--- a/src/Promissum/Promise.swift
+++ b/src/Promissum/Promise.swift
@@ -8,20 +8,105 @@
 
 import Foundation
 
-public let PromissumErrorDomain = "com.nonstrict.Promissum"
+/**
+## A future value
 
+_A Promise represents a future value._
+
+To access it's value, register a handler using the `then` method:
+
+```
+somePromise.then { value in
+  print("The value is: \(value)")
+}
+```
+
+You can register multiple handlers to access the value multiple times.
+To register more multiple handlers, simply call `then` multiple times.
+Once available, the value becomes immutable and will never change.
+
+## Failure
+
+A Promise can fail during the computation of the future value.
+In that case the error can also be accessed by registering a handler with `trap`:
+
+```
+somePromise.trap { error in
+  print("The error is: \(error)")
+}
+```
+
+
+## States
+
+A Promise is always in one of three states: Unresolved, Resolved, or Rejected.
+Once a Promise changes from Unresolved to Resolved/Rejected the appropriate registered handlers are called.
+After the Promise has changed from Unresolved, it will always stay either Resolved or Rejected.
+
+It is possible to register for both the value and the error, like so:
+
+```
+somePromise
+  .then { value in
+    print("The value is: \(value)")
+  }
+  .trap { error in
+    print("The error is: \(error)")
+  }
+```
+
+
+## Types
+
+The full type `Promise<Value, Error>` has two type arguments, for both the value and the error.
+
+For example; the type `Promise<String, NSError>` represents a future value of type `String` that can potentially fail with a `NSError`.
+When creating a Promise yourself, it is recommended to use a custom enum to represent the possible errors cases.
+
+In cases where an error is not applicable, you can use the `NoError` type.
+
+
+## Transforming a Promise value
+
+Similar to `Array`, a Promise has a `map` method to apply a transform the value of a Promise.
+
+In this example an age (Promise of int) is transformed to a future isAdult boolean:
+
+```
+// agePromise has type Promise<Int, NoError>
+// isAdultPromise has type Promise<Bool, NoError>
+let isAdultPromise = agePromise.map { age in age >= 18 }
+
+```
+
+Again, similar to Arrays, `flatMap` is also available.
+
+
+## Creating a Promise
+
+To create a Promise, use a `PromiseSoure`.
+Note that it is often not needed to create a new Promise.
+If an existing Promise is available, transforming that using `map` or `flatMap` is often sufficient.
+
+*/
 public class Promise<Value, Error> {
   private let source: PromiseSource<Value, Error>
 
 
   // MARK: Initializers
 
+  /// Initialize a resolved Promise with a value.
+  ///
+  /// Example: `Promise<Int, NoError>(value: 42)`
   public convenience init(value: Value) {
-    self.init(source: PromiseSource(value: value))
+    self.init(source: PromiseSource(state: .Resolved(value), originalSource: nil, warnUnresolvedDeinit: false))
   }
 
+  /// Initialize a rejected Promise with an error.
+  ///
+  /// Example: `Promise<Int, String>(error: "Oops")`
   public convenience init(error: Error) {
-    self.init(source: PromiseSource(error: error))
+    self.init(source: PromiseSource(state: .Rejected(error), originalSource: nil, warnUnresolvedDeinit: false))
   }
 
   internal init(source: PromiseSource<Value, Error>) {
@@ -31,6 +116,10 @@ public class Promise<Value, Error> {
 
   // MARK: Computed properties
 
+  /// Optionally get the underlying value of this Promise.
+  /// Will be `nil` if Promise is Rejected or still Unresolved.
+  ///
+  /// In most situations it is recommended to register a handler with `then` method instead of directly using this property.
   public var value: Value? {
     switch source.state {
     case .Resolved(let value):
@@ -40,6 +129,10 @@ public class Promise<Value, Error> {
     }
   }
 
+  /// Optionally get the underlying error of this Promise.
+  /// Will be `nil` if Promise is Resolved or still Unresolved.
+  ///
+  /// In most situations it is recommended to register a handler with `trap` method instead of directly using this property.
   public var error: Error? {
     switch source.state {
     case .Rejected(let error):
@@ -49,6 +142,10 @@ public class Promise<Value, Error> {
     }
   }
 
+  /// Optionally get the underlying result of this Promise.
+  /// Will be `nil` if Promise still Unresolved.
+  ///
+  /// In most situations it is recommended to register a handler with `finallyResult` method instead of directly using this property.
   public var result: Result<Value, Error>? {
     switch source.state {
     case .Resolved(let boxed):
@@ -63,6 +160,20 @@ public class Promise<Value, Error> {
 
   // MARK: Attach handlers
 
+  /// Register a handler to be called when value is available.
+  /// The value is passed as an argument to the handler.
+  ///
+  /// The handler is either called directly, if Promise is already resolved, or at a later point in time when the Promise becomes Resolved.
+  ///
+  /// Multiple handlers can be registered by calling `then` multiple times.
+  ///
+  /// ## Execution order
+  /// Handlers registered with `then` are called in the order they have been registered.
+  /// These are interleaved with the other success handlers registered via `finally` or `map`.
+  ///
+  /// ## Dispatch queue
+  /// The handler is synchronously called on the current thread when Promise is already Resolved.
+  /// Or, when Promise is resolved later on, the handler is called synchronously on the thread where `PromiseSource.resolve` is called.
   public func then(handler: Value -> Void) -> Promise<Value, Error> {
 
     let resultHandler: Result<Value, Error> -> Void = { result in
@@ -79,6 +190,20 @@ public class Promise<Value, Error> {
     return self
   }
 
+  /// Register a handler to be called when error is available.
+  /// The error is passed as an argument to the handler.
+  ///
+  /// The handler is either called directly, if Promise is already rejected, or at a later point in time when the Promise becomes Rejected.
+  ///
+  /// Multiple handlers can be registered by calling `trap` multiple times.
+  ///
+  /// ## Execution order
+  /// Handlers registered with `trap` are called in the order they have been registered.
+  /// These are interleaved with the other failure handlers registered via `finally` or `mapError`.
+  ///
+  /// ## Dispatch queue
+  /// The handler is synchronously called on the current thread when Promise is already Rejected.
+  /// Or, when Promise is rejected later on, the handler is called synchronously on the thread where `PromiseSource.reject` is called.
   public func trap(handler: Error -> Void) -> Promise<Value, Error> {
 
     let resultHandler: Result<Value, Error> -> Void = { result in
@@ -95,6 +220,22 @@ public class Promise<Value, Error> {
     return self
   }
 
+  /// Register a handler to be called when Promise is resolved _or_ rejected.
+  /// No argument is passed to the handler.
+  ///
+  /// The handler is either called directly, if Promise is already resolved or rejected,
+  /// or at a later point in time when the Promise becomes Resolved or Rejected.
+  ///
+  /// Multiple handlers can be registered by calling `finally` multiple times.
+  ///
+  /// ## Execution order
+  /// Handlers registered with `finally` are called in the order they have been registered.
+  /// These are interleaved with the other result handlers registered via `then` or `trap`.
+  ///
+  /// ## Dispatch queue
+  /// The handler is synchronously called on the current thread when Promise is already Resolved or Rejected.
+  /// Or, when Promise is resolved or rejected later on,
+  /// the handler is called synchronously on the thread where `PromiseSource.resolve` or `PromiseSource.reject` is called.
   public func finally(handler: () -> Void) -> Promise<Value, Error> {
 
     let resultHandler: Result<Value, Error> -> Void = { _ in
@@ -106,6 +247,22 @@ public class Promise<Value, Error> {
     return self
   }
 
+  /// Register a handler to be called when Promise is resolved _or_ rejected.
+  /// A `Result<Valule, Error>` argument is passed to the handler.
+  ///
+  /// The handler is either called directly, if Promise is already resolved or rejected,
+  /// or at a later point in time when the Promise becomes Resolved or Rejected.
+  ///
+  /// Multiple handlers can be registered by calling `finally` multiple times.
+  ///
+  /// ## Execution order
+  /// Handlers registered with `finally` are called in the order they have been registered.
+  /// These are interleaved with the other result handlers registered via `then` or `trap`.
+  ///
+  /// ## Dispatch queue
+  /// The handler is synchronously called on the current thread when Promise is already Resolved or Rejected.
+  /// Or, when Promise is resolved or rejected later on,
+  /// the handler is called synchronously on the thread where `PromiseSource.resolve` or `PromiseSource.reject` is called.
   public func finallyResult(handler: Result<Value, Error> -> Void) -> Promise<Value, Error> {
 
     source.addOrCallResultHandler(handler)
@@ -116,6 +273,7 @@ public class Promise<Value, Error> {
 
   // MARK: - Value combinators
 
+  /// Return a Promise containing the results of mapping `transform` over the value of `self`.
   public func map<NewValue>(transform: Value -> NewValue) -> Promise<NewValue, Error> {
     let resultSource = PromiseSource<NewValue, Error>(state: .Unresolved, originalSource: self.source, warnUnresolvedDeinit: true)
 
@@ -134,6 +292,7 @@ public class Promise<Value, Error> {
     return resultSource.promise
   }
 
+  /// Returns the flattened result of mapping `transform` over the value of `self`.
   public func flatMap<NewValue>(transform: Value -> Promise<NewValue, Error>) -> Promise<NewValue, Error> {
     let resultSource = PromiseSource<NewValue, Error>()
 
@@ -157,6 +316,7 @@ public class Promise<Value, Error> {
 
   // MARK: Error combinators
 
+  /// Return a Promise containing the results of mapping `transform` over the error of `self`.
   public func mapError<NewError>(transform: Error -> NewError) -> Promise<Value, NewError> {
     let resultSource = PromiseSource<Value, NewError>(state: .Unresolved, originalSource: self.source, warnUnresolvedDeinit: true)
 
@@ -175,6 +335,7 @@ public class Promise<Value, Error> {
     return resultSource.promise
   }
 
+  /// Returns the flattened result of mapping `transform` over the error of `self`.
   public func flatMapError<NewError>(transform: Error -> Promise<Value, NewError>) -> Promise<Value, NewError> {
     let resultSource = PromiseSource<Value, NewError>()
 
@@ -197,6 +358,7 @@ public class Promise<Value, Error> {
 
   // MARK: Result combinators
 
+  /// Returns the flattened result of mapping `transform` over the result of `self`.
   public func mapResult(transform: Result<Value, Error> -> Result<Value, Error>) -> Promise<Value, Error> {
     let resultSource = PromiseSource<Value, Error>(state: .Unresolved, originalSource: self.source, warnUnresolvedDeinit: true)
 
@@ -214,6 +376,7 @@ public class Promise<Value, Error> {
     return resultSource.promise
   }
 
+  /// Return a Promise containing the results of mapping `transform` over the result of `self`.
   public func flatMapResult<NewValue, NewError>(transform: Result<Value, Error> -> Promise<NewValue, NewError>) -> Promise<NewValue, NewError> {
     let resultSource = PromiseSource<NewValue, NewError>()
 

--- a/src/Promissum/Promise.swift
+++ b/src/Promissum/Promise.swift
@@ -175,8 +175,8 @@ public class Promise<Value, Error> {
     return resultSource.promise
   }
 
-  public func flatMapError(transform: Error -> Promise<Value, Error>) -> Promise<Value, Error> {
-    let resultSource = PromiseSource<Value, Error>()
+  public func flatMapError<NewError>(transform: Error -> Promise<Value, NewError>) -> Promise<Value, NewError> {
+    let resultSource = PromiseSource<Value, NewError>()
 
     let handler: Result<Value, Error> -> Void = { result in
       switch result {

--- a/src/Promissum/Promise.swift
+++ b/src/Promissum/Promise.swift
@@ -10,66 +10,66 @@ import Foundation
 
 public let PromissumErrorDomain = "com.nonstrict.Promissum"
 
-public class Promise<T> : PromiseNotifier {
-  internal(set) var state: State<T>
+public class Promise<Value, Error> : PromiseNotifier {
+  internal(set) var state: State<Value, Error>
 
-  internal init(source: PromiseSource<T>) {
+  internal init(source: PromiseSource<Value, Error>) {
     self.state = State.Unresolved(source)
   }
 
-  public init(value: T) {
+  public init(value: Value) {
     state = .Resolved(Box(value))
   }
 
-  public init(error: NSError) {
-    state = .Rejected(error)
+  public init(error: Error) {
+    state = .Rejected(Box(error))
   }
 
-  public func value() -> T? {
+  public func value() -> Value? {
     switch state {
-    case State<T>.Resolved(let boxed):
+    case State<Value, Error>.Resolved(let boxed):
       return boxed.unbox
     default:
       return nil
     }
   }
 
-  public func error() -> NSError? {
+  public func error() -> Error? {
     switch state {
-    case State<T>.Rejected(let error):
-      return error
+    case State<Value, Error>.Rejected(let boxed):
+      return boxed.unbox
     default:
       return nil
     }
   }
 
-  public func result() -> Result<T>? {
+  public func result() -> Result<Value, Error>? {
     switch state {
-    case State<T>.Resolved(let boxed):
+    case State<Value, Error>.Resolved(let boxed):
       return .Value(boxed)
-    case State<T>.Rejected(let error):
-      return .Error(error)
+    case State<Value, Error>.Rejected(let boxed):
+      return .Error(boxed)
     default:
       return nil
     }
   }
 
-  public func then(handler: T -> Void) -> Promise<T> {
+  public func then(handler: Value -> Void) -> Promise<Value, Error> {
     addResolveHandler(handler)
 
     return self
   }
 
-  public func map<U>(transform: T -> U) -> Promise<U> {
-    let source = PromiseSource<U>(originalPromise: self, warnUnresolvedDeinit: true)
+  public func map<NewValue>(transform: Value -> NewValue) -> Promise<NewValue, Error> {
+    let source = PromiseSource<NewValue, Error>(originalPromise: self, warnUnresolvedDeinit: true)
 
-    let handler: Result<T> -> Void = { result in
+    let handler: Result<Value, Error> -> Void = { result in
       switch result {
       case .Value(let boxed):
         let transformed = transform(boxed.unbox)
         source.resolve(transformed)
-      case .Error(let error):
-        source.reject(error)
+      case .Error(let boxed):
+        source.reject(boxed.unbox)
       }
     }
 
@@ -78,18 +78,18 @@ public class Promise<T> : PromiseNotifier {
     return source.promise
   }
 
-  public func flatMap<U>(transform: T -> Promise<U>) -> Promise<U> {
-    let source = PromiseSource<U>()
+  public func flatMap<NewValue>(transform: Value -> Promise<NewValue, Error>) -> Promise<NewValue, Error> {
+    let source = PromiseSource<NewValue, Error>()
 
-    let handler: Result<T> -> Void = { result in
+    let handler: Result<Value, Error> -> Void = { result in
       switch result {
       case .Value(let boxed):
         let transformedPromise = transform(boxed.unbox)
         transformedPromise
           .then(source.resolve)
           .catch(source.reject)
-      case .Error(let error):
-        source.reject(error)
+      case .Error(let boxed):
+        source.reject(boxed.unbox)
       }
     }
 
@@ -98,16 +98,16 @@ public class Promise<T> : PromiseNotifier {
     return source.promise
   }
 
-  public func mapError(transform: NSError -> T) -> Promise<T> {
-    let source = PromiseSource<T>(originalPromise: self, warnUnresolvedDeinit: true)
+  public func mapError<NewError>(transform: Error -> NewError) -> Promise<Value, NewError> {
+    let source = PromiseSource<Value, NewError>(originalPromise: self, warnUnresolvedDeinit: true)
 
-    let handler: Result<T> -> Void = { result in
+    let handler: Result<Value, Error> -> Void = { result in
       switch result {
       case .Value(let boxed):
         source.resolve(boxed.unbox)
-      case .Error(let error):
-        let transformed = transform(error)
-        source.resolve(transformed)
+      case .Error(let boxed):
+        let transformed = transform(boxed.unbox)
+        source.reject(transformed)
       }
     }
 
@@ -116,15 +116,15 @@ public class Promise<T> : PromiseNotifier {
     return source.promise
   }
 
-  public func flatMapError(transform: NSError -> Promise<T>) -> Promise<T> {
-    let source = PromiseSource<T>()
+  public func flatMapError(transform: Error -> Promise<Value, Error>) -> Promise<Value, Error> {
+    let source = PromiseSource<Value, Error>()
 
-    let handler: Result<T> -> Void = { result in
+    let handler: Result<Value, Error> -> Void = { result in
       switch result {
       case .Value(let boxed):
         source.resolve(boxed.unbox)
-      case .Error(let error):
-        let transformedPromise = transform(error)
+      case .Error(let boxed):
+        let transformedPromise = transform(boxed.unbox)
         transformedPromise
           .then(source.resolve)
           .catch(source.reject)
@@ -136,19 +136,23 @@ public class Promise<T> : PromiseNotifier {
     return source.promise
   }
 
-  public func catch(handler: NSError -> Void) -> Promise<T> {
+  public func catch(handler: Error -> Void) -> Promise<Value, Error> {
 
     addErrorHandler(handler)
 
     return self
   }
 
-  public func mapResult(transform: Result<T> -> T) -> Promise<T> {
-    let source = PromiseSource<T>()
+  public func mapResult(transform: Result<Value, Error> -> Result<Value, Error>) -> Promise<Value, Error> {
+    let source = PromiseSource<Value, Error>()
 
-    let handler: Result<T> -> Void = { result in
-      let transformed = transform(result)
-      source.resolve(transformed)
+    let handler: Result<Value, Error> -> Void = { result in
+      switch transform(result) {
+      case .Value(let boxed):
+        source.resolve(boxed.unbox)
+      case .Error(let boxed):
+        source.reject(boxed.unbox)
+      }
     }
 
     addResultHandler(handler)
@@ -156,10 +160,10 @@ public class Promise<T> : PromiseNotifier {
     return source.promise
   }
 
-  public func flatMapResult<U>(transform: Result<T> -> Promise<U>) -> Promise<U> {
-    let source = PromiseSource<U>()
+  public func flatMapResult<NewValue, NewError>(transform: Result<Value, Error> -> Promise<NewValue, NewError>) -> Promise<NewValue, NewError> {
+    let source = PromiseSource<NewValue, NewError>()
 
-    let handler: Result<T> -> Void = { result in
+    let handler: Result<Value, Error> -> Void = { result in
       let transformedPromise = transform(result)
       transformedPromise
         .then(source.resolve)
@@ -171,14 +175,14 @@ public class Promise<T> : PromiseNotifier {
     return source.promise
   }
 
-  public func finallyResult(handler: Result<T> -> Void) -> Promise<T> {
+  public func finallyResult(handler: Result<Value, Error> -> Void) -> Promise<Value, Error> {
 
     addResultHandler(handler)
 
     return self
   }
 
-  public func finally(handler: () -> Void) -> Promise<T> {
+  public func finally(handler: () -> Void) -> Promise<Value, Error> {
 
     addResultHandler({ _ in handler() })
 
@@ -189,32 +193,32 @@ public class Promise<T> : PromiseNotifier {
     addResultHandler({ _ in handler() })
   }
 
-  internal func addResultHandler(handler: Result<T> -> Void) {
+  internal func addResultHandler(handler: Result<Value, Error> -> Void) {
 
     switch state {
-    case State<T>.Unresolved(let source):
+    case State<Value, Error>.Unresolved(let source):
       // Save handler for later
       source.addHander(handler)
 
-    case State<T>.Resolved(let boxed):
+    case State<Value, Error>.Resolved(let boxed):
       // Value is already available, call handler immediately
       handler(Result.Value(boxed))
 
-    case State<T>.Rejected(let error):
+    case State<Value, Error>.Rejected(let boxed):
       // Error is already available, call handler immediately
-      handler(Result.Error(error))
+      handler(Result.Error(boxed))
 
     }
   }
 
   // Convinience functions
 
-  private func addResolveHandler(handler: T -> Void) {
+  private func addResolveHandler(handler: Value -> Void) {
 
     switch state {
-    case State<T>.Unresolved(let source):
+    case State<Value, Error>.Unresolved(let source):
       // Save handler for later
-      let resultHandler: Result<T> -> Void = { result in
+      let resultHandler: Result<Value, Error> -> Void = { result in
         switch result {
         case .Value(let boxed):
           handler(boxed.unbox)
@@ -224,37 +228,37 @@ public class Promise<T> : PromiseNotifier {
       }
       source.addHander(resultHandler)
 
-    case State<T>.Resolved(let boxed):
+    case State<Value, Error>.Resolved(let boxed):
       // Value is already available, call handler immediately
       handler(boxed.unbox)
 
-    case State<T>.Rejected:
+    case State<Value, Error>.Rejected:
       break
 
     }
   }
 
-  private func addErrorHandler(handler: NSError -> Void) {
+  private func addErrorHandler(handler: Error -> Void) {
 
     switch state {
-    case State<T>.Unresolved(let source):
+    case State<Value, Error>.Unresolved(let source):
       // Save handler for later
-      let resultHandler: Result<T> -> Void = { result in
+      let resultHandler: Result<Value, Error> -> Void = { result in
         switch result {
         case .Value:
           break
-        case .Error(let error):
-          handler(error)
+        case .Error(let boxed):
+          handler(boxed.unbox)
         }
       }
       source.addHander(resultHandler)
 
-    case State<T>.Resolved(let boxed):
+    case State<Value, Error>.Resolved(let boxed):
       break
 
-    case State<T>.Rejected(let error):
+    case State<Value, Error>.Rejected(let boxed):
       // Error is already available, call handler immediately
-      handler(error)
+      handler(boxed.unbox)
     }
   }
 }

--- a/src/Promissum/PromiseSource.swift
+++ b/src/Promissum/PromiseSource.swift
@@ -9,31 +9,87 @@
 import Foundation
 
 // This Notifier is used to implement Promise.map
-protocol OriginalSource {
+internal protocol OriginalSource {
   func registerHandler(handler: () -> Void)
 }
 
+/**
+## Creating Promises
+
+A PromiseSource is used to create a Promise that can be resolved or rejected.
+
+Example:
+
+```
+let source = PromiseSource<Int, String>()
+let promise = source.promise
+
+// Register handlers with Promise
+promise
+  .then { value in
+    print("The value is: \(value)")
+  }
+  .trap { error in
+    print("The error is: \(error)")
+  }
+
+// Resolve the source (will call the Promise handler)
+source.resolve(42)
+```
+
+Once a PromiseSource is Resolved or Rejected it cannot be changed anymore.
+All subsequent calls to `resolve` and `reject` are ignored.
+
+## When to use
+A PromiseSource is needed when transforming an asynchronous operation into a Promise.
+
+Example:
+```
+func someOperationPromise() -> Promise<String, ErrorType> {
+  let source = PromiseSource<String, ErrorType>()
+
+  someOperation(callback: { (error, value) in
+    if let error = error {
+      source.reject(error)
+    }
+    if let value = value {
+      source.resolve(value)
+    }
+  })
+
+  return promise
+}
+```
+
+## Memory management
+Make sure, when creating a PromiseSource, that someone retains a reference to the source.
+
+In the example above the `someOperation` retains the callback.
+But in some cases, often when using weak delegates, the callback is not retained.
+In that case, you must manually retain the PromiseSource, or the Promise will never complete.
+
+Note that `PromiseSource.deinit` by default will log a warning when an unresolved PromiseSource is deallocated.
+
+*/
 public class PromiseSource<Value, Error> : OriginalSource {
   typealias ResultHandler = Result<Value, Error> -> Void
-  public var state: State<Value, Error>
-  public var warnUnresolvedDeinit: Bool
 
   private var handlers: [Result<Value, Error> -> Void] = []
-
   private let originalSource: OriginalSource?
+
+  /// The current state of the PromiseSource
+  public var state: State<Value, Error>
+
+  /// Print a warning on deinit of an unresolved PromiseSource
+  public var warnUnresolvedDeinit: Bool
 
   // MARK: Initializers & deinit
 
+  /// Initialize a new Unresolved PromiseSource
+  ///
+  /// - parameter warnUnresolvedDeinit: Print a warning on deinit of an unresolved PromiseSource
   public convenience init(warnUnresolvedDeinit: Bool = true) {
     self.init(state: .Unresolved, originalSource: nil, warnUnresolvedDeinit: warnUnresolvedDeinit)
-  }
-
-  public convenience init(value: Value, warnUnresolvedDeinit: Bool = true) {
-    self.init(state: .Resolved(value), originalSource: nil, warnUnresolvedDeinit: warnUnresolvedDeinit)
-  }
-
-  public convenience init(error: Error, warnUnresolvedDeinit: Bool = true) {
-    self.init(state: .Rejected(error), originalSource: nil, warnUnresolvedDeinit: warnUnresolvedDeinit)
   }
 
   internal init(state: State<Value, Error>, originalSource: OriginalSource?, warnUnresolvedDeinit: Bool) {
@@ -57,6 +113,7 @@ public class PromiseSource<Value, Error> : OriginalSource {
 
   // MARK: Computed properties
 
+  /// Promise related to this PromiseSource
   public var promise: Promise<Value, Error> {
     return Promise(source: self)
   }
@@ -64,6 +121,9 @@ public class PromiseSource<Value, Error> : OriginalSource {
 
   // MARK: Resolve / reject
 
+  /// Resolve an Unresolved PromiseSource with supplied value.
+  ///
+  /// When called on a PromiseSource that is already Resolved or Rejected, the call is ignored.
   public func resolve(value: Value) {
 
     switch state {
@@ -76,6 +136,10 @@ public class PromiseSource<Value, Error> : OriginalSource {
     }
   }
 
+
+  /// Reject an Unresolved PromiseSource with supplied error.
+  ///
+  /// When called on a PromiseSource that is already Resolved or Rejected, the call is ignored.
   public func reject(error: Error) {
 
     switch state {

--- a/src/Promissum/Result.swift
+++ b/src/Promissum/Result.swift
@@ -8,23 +8,24 @@
 
 import Foundation
 
-public enum Result<T> {
-  case Value(Box<T>)
-  case Error(NSError)
+public enum Result<TValue, TError> {
+  case Value(Box<TValue>)
+  case Error(Box<TError>)
 
-  public func value() -> T? {
+  public func value() -> TValue? {
     switch self {
     case .Value(let boxed):
-      let val = boxed.unbox
-      return val
+      let value = boxed.unbox
+      return value
     case .Error:
       return nil
     }
   }
 
-  public func error() -> NSError? {
+  public func error() -> TError? {
     switch self {
-    case .Error(let error):
+    case .Error(let boxed):
+      let error = boxed.unbox
       return error
     case .Value:
       return nil
@@ -37,9 +38,10 @@ extension Result: Printable {
   public var description: String {
     switch self {
     case .Value(let boxed):
-      let val = boxed.unbox
-      return "Value(\(val))"
-    case .Error(let error):
+      let value = boxed.unbox
+      return "Value(\(value))"
+    case .Error(let boxed):
+      let error = boxed.unbox
       return "Error(\(error))"
     }
   }

--- a/src/Promissum/Result.swift
+++ b/src/Promissum/Result.swift
@@ -8,10 +8,12 @@
 
 import Foundation
 
+/// The Result type is used for Promises that are Resolved or Rejected.
 public enum Result<TValue, TError> {
   case Value(TValue)
   case Error(TError)
 
+  /// Optional value, set when Result is Value.
   public var value: TValue? {
     switch self {
     case .Value(let value):
@@ -21,6 +23,7 @@ public enum Result<TValue, TError> {
     }
   }
 
+  /// Optional error, set when Result is Error.
   public var error: TError? {
     switch self {
     case .Error(let error):

--- a/src/Promissum/State.swift
+++ b/src/Promissum/State.swift
@@ -13,10 +13,12 @@ public class Box<T> {
   public init(_ value: T) { self.unbox = value }
 }
 
-public enum State<T> {
-  case Unresolved(PromiseSource<T>)
-  case Resolved(Box<T>)
-  case Rejected(NSError)
+public enum NoError { }
+
+public enum State<Value, Error> {
+  case Unresolved(PromiseSource<Value, Error>)
+  case Resolved(Box<Value>)
+  case Rejected(Box<Error>)
 }
 
 extension State: Printable {
@@ -26,9 +28,10 @@ extension State: Printable {
     case .Unresolved:
       return "Unresolved"
     case .Resolved(let boxed):
-      let val = boxed.unbox
-      return "Resolved(\(val))"
-    case .Rejected(let error):
+      let value = boxed.unbox
+      return "Resolved(\(value))"
+    case .Rejected(let boxed):
+      let error = boxed.unbox
       return "Rejected(\(error))"
     }
   }

--- a/src/Promissum/State.swift
+++ b/src/Promissum/State.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
+/// Type used when there is no error possible.
 public enum NoError : ErrorType {}
 
+/// State of a PromiseSource.
 public enum State<Value, Error> {
   case Unresolved
   case Resolved(Value)

--- a/src/Promissum/State.swift
+++ b/src/Promissum/State.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum NoError {}
+public enum NoError : ErrorType {}
 
 public enum State<Value, Error> {
   case Unresolved

--- a/src/PromissumTests/InitialErrorTests.swift
+++ b/src/PromissumTests/InitialErrorTests.swift
@@ -10,6 +10,8 @@ import Foundation
 import XCTest
 import Promissum
 
+let PromissumErrorDomain = "com.nonstrict.Promissum"
+
 class InitialErrorTests: XCTestCase {
 
   func testError() {

--- a/src/PromissumTests/InitialErrorTests.swift
+++ b/src/PromissumTests/InitialErrorTests.swift
@@ -15,7 +15,7 @@ class InitialErrorTests: XCTestCase {
   func testError() {
     var error: NSError?
 
-    let p = Promise<Int>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
+    let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
 
     error = p.error()
 
@@ -25,7 +25,7 @@ class InitialErrorTests: XCTestCase {
   func testErrorVoid() {
     var error: NSError?
 
-    let p = Promise<Int>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
+    let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
 
     p.catch { e in
       error = e
@@ -37,10 +37,10 @@ class InitialErrorTests: XCTestCase {
   func testErrorMap() {
     var value: Int?
 
-    let p = Promise<Int>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
+    let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
       .mapError { $0.code + 1 }
 
-    p.then { x in
+    p.catch { x in
       value = x
     }
 
@@ -50,7 +50,7 @@ class InitialErrorTests: XCTestCase {
   func testErrorFlatMap() {
     var value: Int?
 
-    let p = Promise<Int>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
+    let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
       .flatMapError { Promise(value: $0.code + 1) }
 
     p.then { x in
@@ -63,7 +63,7 @@ class InitialErrorTests: XCTestCase {
   func testErrorFlatMap2() {
     var error: NSError?
 
-    let p = Promise<Int>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
+    let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
       .flatMapError { Promise(error: NSError(domain: PromissumErrorDomain, code: $0.code + 1, userInfo: nil)) }
 
     p.catch { e in
@@ -76,7 +76,7 @@ class InitialErrorTests: XCTestCase {
   func testFinally() {
     var finally: Bool = false
 
-    let p = Promise<Int>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
+    let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
 
     p.finally {
       finally = true

--- a/src/PromissumTests/InitialErrorTests.swift
+++ b/src/PromissumTests/InitialErrorTests.swift
@@ -51,7 +51,7 @@ class InitialErrorTests: XCTestCase {
     var value: Int?
 
     let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
-      .flatMapError { Promise(value: $0.code + 1) }
+      .flatMapError { Promise<Int, String>(value: $0.code + 1) }
 
     p.then { x in
       value = x

--- a/src/PromissumTests/InitialValueTests.swift
+++ b/src/PromissumTests/InitialValueTests.swift
@@ -15,7 +15,7 @@ class InitialValueTests: XCTestCase {
   func testValue() {
     var value: Int?
 
-    let p = Promise(value: 42)
+    let p: Promise<Int, NSError> = Promise(value: 42)
 
     value = p.value()
 
@@ -25,7 +25,7 @@ class InitialValueTests: XCTestCase {
   func testValueVoid() {
     var value: Int?
 
-    let p = Promise(value: 42)
+    let p: Promise<Int, NSError> = Promise(value: 42)
 
     p.then { x in
       value = x
@@ -37,7 +37,7 @@ class InitialValueTests: XCTestCase {
   func testValueMap() {
     var value: Int?
 
-    let p = Promise(value: 42)
+    let p: Promise<Int, NSError> = Promise(value: 42)
       .map { $0 + 1 }
 
     p.then { x in
@@ -50,7 +50,7 @@ class InitialValueTests: XCTestCase {
   func testValueFlatMap() {
     var value: Int?
 
-    let p = Promise(value: 42)
+    let p: Promise<Int, NSError> = Promise(value: 42)
       .flatMap { Promise(value: $0 + 1) }
 
     p.then { x in
@@ -63,7 +63,7 @@ class InitialValueTests: XCTestCase {
   func testFinally() {
     var finally: Bool = false
 
-    let p = Promise<Int>(value: 42)
+    let p = Promise<Int, NSError>(value: 42)
 
     p.finally {
       finally = true

--- a/src/PromissumTests/MultipleErrorTests.swift
+++ b/src/PromissumTests/MultipleErrorTests.swift
@@ -15,7 +15,7 @@ class MultipleErrorTests: XCTestCase {
   func testValueVoid() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.catch { _ in
@@ -33,14 +33,14 @@ class MultipleErrorTests: XCTestCase {
   func testValueMap() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.catch { _ in
       calls += 1
     }
     p.mapError { $0.code + 1 }
-      .then { _ in
+      .catch { _ in
         calls += 1
       }
 
@@ -52,7 +52,7 @@ class MultipleErrorTests: XCTestCase {
   func testValueFlatMap() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.catch { _ in
@@ -71,7 +71,7 @@ class MultipleErrorTests: XCTestCase {
   func testValueFlatMap2() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.catch { _ in
@@ -90,9 +90,9 @@ class MultipleErrorTests: XCTestCase {
   func testValueFlatMap3() {
     var calls = 0
 
-    let source1 = PromiseSource<Int>()
+    let source1 = PromiseSource<Int, NSError>()
     let p1 = source1.promise
-    let source2 = PromiseSource<Int>()
+    let source2 = PromiseSource<Int, NSError>()
     let p2 = source2.promise
 
     p1.catch { _ in
@@ -112,9 +112,9 @@ class MultipleErrorTests: XCTestCase {
   func testValueFlatMap4() {
     var calls = 0
 
-    let source1 = PromiseSource<Int>()
+    let source1 = PromiseSource<Int, NSError>()
     let p1 = source1.promise
-    let source2 = PromiseSource<Int>()
+    let source2 = PromiseSource<Int, NSError>()
     let p2 = source2.promise
 
     p1.catch { _ in
@@ -134,7 +134,7 @@ class MultipleErrorTests: XCTestCase {
   func testFinally() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.finally {

--- a/src/PromissumTests/MultipleErrorTests.swift
+++ b/src/PromissumTests/MultipleErrorTests.swift
@@ -58,7 +58,7 @@ class MultipleErrorTests: XCTestCase {
     p.catch { _ in
       calls += 1
     }
-    p.flatMapError { Promise(value: $0.code + 1) }
+    p.flatMapError { Promise<Int, String>(value: $0.code + 1) }
       .then { _ in
         calls += 1
       }
@@ -77,7 +77,7 @@ class MultipleErrorTests: XCTestCase {
     p.catch { _ in
       calls += 1
     }
-    p.flatMapError { Promise(error: NSError(domain: PromissumErrorDomain, code: $0.code + 1, userInfo: nil))  }
+    p.flatMapError { Promise<Int, String>(error: "\($0.code + 1)")  }
       .catch { _ in
         calls += 1
       }

--- a/src/PromissumTests/MultipleValueTests.swift
+++ b/src/PromissumTests/MultipleValueTests.swift
@@ -15,7 +15,7 @@ class MultipleValueTests: XCTestCase {
   func testValueVoid() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { _ in
@@ -33,7 +33,7 @@ class MultipleValueTests: XCTestCase {
   func testValueMap() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { _ in
@@ -52,7 +52,7 @@ class MultipleValueTests: XCTestCase {
   func testValueFlatMap() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { _ in
@@ -71,7 +71,7 @@ class MultipleValueTests: XCTestCase {
   func testFinally() {
     var calls = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.finally {

--- a/src/PromissumTests/ResolveRejectTests.swift
+++ b/src/PromissumTests/ResolveRejectTests.swift
@@ -15,7 +15,7 @@ class ResolveRejectTests: XCTestCase {
   func testResolveReject() {
     var state = ""
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { _ in
@@ -34,7 +34,7 @@ class ResolveRejectTests: XCTestCase {
   func testRejectResolve() {
     var state = ""
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { _ in
@@ -53,7 +53,7 @@ class ResolveRejectTests: XCTestCase {
   func testResolveFinally() {
     var state = ""
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { _ in
@@ -71,7 +71,7 @@ class ResolveRejectTests: XCTestCase {
   func testFinallyResolve() {
     var state = ""
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.finally {

--- a/src/PromissumTests/SideEffectOrderTests.swift
+++ b/src/PromissumTests/SideEffectOrderTests.swift
@@ -15,7 +15,7 @@ class SideEffectOrderTests : XCTestCase {
   func testThen() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p
@@ -36,7 +36,7 @@ class SideEffectOrderTests : XCTestCase {
   func testCatch() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p
@@ -57,10 +57,10 @@ class SideEffectOrderTests : XCTestCase {
   func testMap() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
-    let q: Promise<Int> = p
+    let q: Promise<Int, NSError> = p
       .then { value in
         XCTAssertEqual(value, 42, "Value should be 42")
 
@@ -89,10 +89,10 @@ class SideEffectOrderTests : XCTestCase {
   func testMap2() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
-    let q: Promise<Int> = p
+    let q: Promise<Int, NSError> = p
       .map { value in
         XCTAssertEqual(value, 42, "Value should be 42")
 
@@ -123,16 +123,16 @@ class SideEffectOrderTests : XCTestCase {
   func testMapError() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
-    let q: Promise<Int> = p
+    let q: Promise<Int, NSError> = p
       .mapError { error in
         XCTAssertEqual(error.code, 42, "Error should be 42")
 
         step += 1
         XCTAssertEqual(step, 1, "Should be step 1")
-        return error.code + 1
+        return NSError(domain: PromissumErrorDomain, code: error.code + 1, userInfo: nil)
       }
 
     p.catch { error in
@@ -142,8 +142,8 @@ class SideEffectOrderTests : XCTestCase {
       XCTAssertEqual(step, 2, "Should be step 2")
     }
 
-    q.then { value in
-      XCTAssertEqual(value, 43, "Value should be 43")
+    q.catch { error in
+      XCTAssertEqual(error.code, 43, "Value should be 43")
 
       step += 1
       XCTAssertEqual(step, 3, "Should be step 3")
@@ -157,10 +157,10 @@ class SideEffectOrderTests : XCTestCase {
   func testErrorMap() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
-    let q: Promise<Int> = p
+    let q: Promise<Int, NSError> = p
       .map { value in
         step += 1
         XCTFail("Shouldn't happen")
@@ -189,10 +189,10 @@ class SideEffectOrderTests : XCTestCase {
   func testFlatMap() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
-    let q: Promise<Int> = p
+    let q: Promise<Int, NSError> = p
       .then { value in
         XCTAssertEqual(value, 42, "Value should be 42")
 
@@ -221,10 +221,10 @@ class SideEffectOrderTests : XCTestCase {
   func testFlatMapError() {
     var step = 0
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
-    let q: Promise<Int> = p
+    let q: Promise<Int, NSError> = p
       .catch { error in
         XCTAssertEqual(error.code, 42, "Value should be 42")
 

--- a/src/PromissumTests/SourceErrorTests.swift
+++ b/src/PromissumTests/SourceErrorTests.swift
@@ -61,7 +61,7 @@ class SourceErrorTests: XCTestCase {
 
     let source = PromiseSource<Int, NSError>()
     let p = source.promise
-      .flatMapError { Promise(value: $0.code + 1) }
+      .flatMapError { Promise<Int, String>(value: $0.code + 1) }
 
     p.then { x in
       value = x

--- a/src/PromissumTests/SourceErrorTests.swift
+++ b/src/PromissumTests/SourceErrorTests.swift
@@ -15,7 +15,7 @@ class SourceErrorTests: XCTestCase {
   func testError() {
     var error: NSError?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     error = p.error()
@@ -28,7 +28,7 @@ class SourceErrorTests: XCTestCase {
   func testErrorVoid() {
     var error: NSError?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.catch { e in
@@ -43,11 +43,11 @@ class SourceErrorTests: XCTestCase {
   func testErrorMap() {
     var value: Int?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
       .mapError { $0.code + 1 }
 
-    p.then { x in
+    p.catch { x in
       value = x
     }
 
@@ -59,7 +59,7 @@ class SourceErrorTests: XCTestCase {
   func testErrorFlatMapValue() {
     var value: Int?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
       .flatMapError { Promise(value: $0.code + 1) }
 
@@ -75,7 +75,7 @@ class SourceErrorTests: XCTestCase {
   func testErrorFlatMapError() {
     var error: NSError?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
       .flatMapError { Promise(error: NSError(domain: PromissumErrorDomain, code: $0.code + 1, userInfo: nil)) }
 
@@ -91,7 +91,7 @@ class SourceErrorTests: XCTestCase {
   func testFinally() {
     var finally: Bool = false
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.finally {

--- a/src/PromissumTests/SourceValueTests.swift
+++ b/src/PromissumTests/SourceValueTests.swift
@@ -15,7 +15,7 @@ class SourceValueTests: XCTestCase {
   func testValue() {
     var value: Int?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     value = p.value()
@@ -28,7 +28,7 @@ class SourceValueTests: XCTestCase {
   func testValueVoid() {
     var value: Int?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.then { x in
@@ -43,7 +43,7 @@ class SourceValueTests: XCTestCase {
   func testValueMap() {
     var value: Int?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
       .map { $0 + 1 }
 
@@ -59,7 +59,7 @@ class SourceValueTests: XCTestCase {
   func testValueFlatMap() {
     var value: Int?
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
       .flatMap { Promise(value: $0 + 1) }
 
@@ -75,7 +75,7 @@ class SourceValueTests: XCTestCase {
   func testFinally() {
     var finally: Bool = false
 
-    let source = PromiseSource<Int>()
+    let source = PromiseSource<Int, NSError>()
     let p = source.promise
 
     p.finally {


### PR DESCRIPTION
**To be merged when Swift 2 is out of beta.**

Working on Swift 2 support. Removed `Box<T>`, renamed `catch` to `trap`.
I'm not sure about the `trap` name yet, looking for something better.
