### PR TITLE
Result type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,13 @@ import PackageDescription
 
 let package = Package(
   name: "Promissum",
+  products: [
+    .library(name: "Promissum", targets: ["Promissum"]),
+  ],
   dependencies: [],
   targets: [
     .target(name: "Promissum"),
+    .testTarget(name: "PromissumTests", dependencies: ["Promissum"]),
   ]
 )
 

--- a/Promissum.podspec
+++ b/Promissum.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Promissum"
-  s.version      = "3.1.0"
+  s.version      = "4.0.0"
   s.license      = "MIT"
 
   s.summary      = "A promises library written in Swift featuring combinators like map, flatMap, whenAll, whenAny."
@@ -27,7 +27,7 @@ Promissum really shines when used to combine asynchronous operations from differ
   s.source          = { :git => "https://github.com/tomlokhorst/Promissum.git", :tag => s.version }
   s.requires_arc    = true
   s.default_subspec = "Core"
-  s.swift_version   = '4.2'
+  s.swift_version   = "5.0"
 
   s.subspec "Core" do |ss|
     ss.source_files  = "Sources/Promissum"

--- a/Sources/Promissum/Combinators.swift
+++ b/Sources/Promissum/Combinators.swift
@@ -172,7 +172,7 @@ extension PromiseSource where Value == Void {
   }
 }
 
-extension Promise where Error : Swift.Error {
+extension Promise {
 
   /// Returns a Promise where the error is casted to an ErrorType.
   public func mapError() -> Promise<Value, Swift.Error> {

--- a/Sources/Promissum/Promise.swift
+++ b/Sources/Promissum/Promise.swift
@@ -89,7 +89,7 @@ Note that it is often not needed to create a new Promise.
 If an existing Promise is available, transforming that using `map` or `flatMap` is often sufficient.
 
 */
-public class Promise<Value, Error> {
+public class Promise<Value, Error> where Error: Swift.Error {
   private let source: PromiseSource<Value, Error>
 
 
@@ -104,7 +104,7 @@ public class Promise<Value, Error> {
 
   /// Initialize a rejected Promise with an error.
   ///
-  /// Example: `Promise<Int, String>(error: "Oops")`
+  /// Example: `Promise<Int, Error>(error: MyError(message: "Oops"))`
   public init(error: Error) {
     self.source = PromiseSource(error: error)
   }
@@ -147,10 +147,10 @@ public class Promise<Value, Error> {
   public var result: Result<Value, Error>? {
     switch source.state {
     case .resolved(let boxed):
-      return .value(boxed)
+      return .success(boxed)
 
     case .rejected(let boxed):
-      return .error(boxed)
+      return .failure(boxed)
 
     default:
       return nil
@@ -179,10 +179,10 @@ public class Promise<Value, Error> {
 
     let resultHandler: (Result<Value, Error>) -> Void = { result in
       switch result {
-      case .value(let value):
+      case .success(let value):
         handler(value)
 
-      case .error:
+      case .failure:
         break
       }
     }
@@ -211,10 +211,10 @@ public class Promise<Value, Error> {
 
     let resultHandler: (Result<Value, Error>) -> Void = { result in
       switch result {
-      case .value:
+      case .success:
         break
 
-      case .error(let error):
+      case .failure(let error):
         handler(error)
       }
     }
@@ -319,11 +319,11 @@ public class Promise<Value, Error> {
 
     let handler: (Result<Value, Error>) -> Void = { result in
       switch result {
-      case .value(let value):
+      case .success(let value):
         let transformed = transform(value)
         resultSource.resolve(transformed)
 
-      case .error(let error):
+      case .failure(let error):
         resultSource.reject(error)
       }
     }
@@ -344,12 +344,12 @@ public class Promise<Value, Error> {
 
     let handler: (Result<Value, Error>) -> Void = { result in
       switch result {
-      case .value(let value):
+      case .success(let value):
         let transformedPromise = transform(value)
         transformedPromise
           .then(resultSource.resolve)
           .trap(resultSource.reject)
-      case .error(let error):
+      case .failure(let error):
         resultSource.reject(error)
       }
     }
@@ -373,10 +373,10 @@ public class Promise<Value, Error> {
 
     let handler: (Result<Value, Error>) -> Void = { result in
       switch result {
-      case .value(let value):
+      case .success(let value):
         resultSource.resolve(value)
 
-      case .error(let error):
+      case .failure(let error):
         let transformed = transform(error)
         resultSource.reject(transformed)
       }
@@ -398,9 +398,9 @@ public class Promise<Value, Error> {
 
     let handler: (Result<Value, Error>) -> Void = { result in
       switch result {
-      case .value(let value):
+      case .success(let value):
         resultSource.resolve(value)
-      case .error(let error):
+      case .failure(let error):
         let transformedPromise = transform(error)
         transformedPromise
           .then(resultSource.resolve)
@@ -426,10 +426,10 @@ public class Promise<Value, Error> {
 
     let handler: (Result<Value, Error>) -> Void = { result in
       switch transform(result) {
-      case .value(let value):
+      case .success(let value):
         resultSource.resolve(value)
 
-      case .error(let error):
+      case .failure(let error):
         resultSource.reject(error)
       }
     }

--- a/Sources/Promissum/PromiseSource.swift
+++ b/Sources/Promissum/PromiseSource.swift
@@ -66,7 +66,7 @@ In that case, you must manually retain the PromiseSource, or the Promise will ne
 Note that `PromiseSource.deinit` by default will log a warning when an unresolved PromiseSource is deallocated.
 
 */
-public class PromiseSource<Value, Error> {
+public class PromiseSource<Value, Error> where Error: Swift.Error {
   internal let dispatchKey: DispatchSpecificKey<Void>
   internal let dispatchMethod: DispatchMethod
 
@@ -137,7 +137,7 @@ public class PromiseSource<Value, Error> {
   ///
   /// When called on a PromiseSource that is already Resolved or Rejected, the call is ignored.
   public func resolve(_ value: Value) {
-    resolveResult(.value(value))
+    resolveResult(.success(value))
   }
 
 
@@ -145,7 +145,7 @@ public class PromiseSource<Value, Error> {
   ///
   /// When called on a PromiseSource that is already Resolved or Rejected, the call is ignored.
   public func reject(_ error: Error) {
-    resolveResult(.error(error))
+    resolveResult(.failure(error))
   }
 
   internal func resolveResult(_ result: Result<Value, Error>) {
@@ -213,11 +213,11 @@ extension PromiseSource {
 
       case .resolved(let value):
         // Value is already available, call handler immediately
-        return PromiseSourceAction(result: .value(value), handlers: [handler])
+        return PromiseSourceAction(result: .success(value), handlers: [handler])
 
       case .rejected(let error):
         // Error is already available, call handler immediately
-        return PromiseSourceAction(result: .error(error), handlers: [handler])
+        return PromiseSourceAction(result: .failure(error), handlers: [handler])
       }
     }
   }

--- a/Sources/Promissum/Result.swift
+++ b/Sources/Promissum/Result.swift
@@ -9,52 +9,35 @@
 import Foundation
 
 /// The Result type is used for Promises that are Resolved or Rejected.
-public enum Result<TValue, TError> {
-  case value(TValue)
-  case error(TError)
+extension Result {
 
   /// Optional value, set when Result is Value.
-  public var value: TValue? {
+  public var value: Success? {
     switch self {
-    case .value(let value):
+    case .success(let value):
       return value
-
-    case .error:
+    case .failure:
       return nil
     }
   }
 
   /// Optional error, set when Result is Error.
-  public var error: TError? {
+  public var error: Failure? {
     switch self {
-    case .error(let error):
+    case .failure(let error):
       return error
-
-    case .value:
+    case .success:
       return nil
     }
   }
 
-  internal var state: State<TValue, TError> {
+  internal var state: State<Success, Failure> {
     switch self {
-    case .value(let boxed):
+    case .success(let boxed):
       return .resolved(boxed)
 
-    case .error(let error):
+    case .failure(let error):
       return .rejected(error)
-    }
-  }
-}
-
-extension Result: CustomStringConvertible {
-
-  public var description: String {
-    switch self {
-    case .value(let value):
-      return "value(\(value))"
-
-    case .error(let error):
-      return "error(\(error))"
     }
   }
 }

--- a/Tests/PromissumTests/DispatchOnTests.swift
+++ b/Tests/PromissumTests/DispatchOnTests.swift
@@ -379,7 +379,7 @@ class DispatchOnTests: XCTestCase {
 
         calls += 1
 
-        return Result.error(NSError(code: result.value! + 1))
+        return Result.failure(NSError(code: result.value! + 1))
       }
       .dispatch(on: test2Queue)
       .mapResult { result -> Result<Int, NSError> in
@@ -388,7 +388,7 @@ class DispatchOnTests: XCTestCase {
 
         calls += 1
 
-        return Result.value(result.error!.code + 1)
+        return Result.success(result.error!.code + 1)
       }
       .dispatch(on: test3Queue)
       .mapResult { result -> Result<Int, NSError> in
@@ -397,7 +397,7 @@ class DispatchOnTests: XCTestCase {
 
         calls += 1
 
-        return Result.value(result.value! + 1)
+        return Result.success(result.value! + 1)
       }
 
     source.resolve(40)

--- a/Tests/PromissumTests/InitialErrorTests.swift
+++ b/Tests/PromissumTests/InitialErrorTests.swift
@@ -48,10 +48,10 @@ class InitialErrorTests: XCTestCase {
     var value: Int?
 
     let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
-      .mapError { $0.code + 1 }
+      .mapError { NSError(code: $0.code + 1) }
 
     p.trap { x in
-      value = x
+      value = x.code
     }
 
     expectation(p) {
@@ -63,7 +63,7 @@ class InitialErrorTests: XCTestCase {
     var value: Int?
 
     let p = Promise<Int, NSError>(error: NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
-      .flatMapError { Promise<Int, String>(value: $0.code + 1) }
+      .flatMapError { Promise<Int, NSError>(value: $0.code + 1) }
 
     p.then { x in
       value = x

--- a/Tests/PromissumTests/MultipleErrorTests.swift
+++ b/Tests/PromissumTests/MultipleErrorTests.swift
@@ -43,7 +43,7 @@ class MultipleErrorTests: XCTestCase {
     }
 
     let q = p
-      .mapError { $0.code + 1 }
+      .mapError { NSError(code: $0.code + 1) }
       .trap { _ in
         calls += 1
       }
@@ -66,7 +66,7 @@ class MultipleErrorTests: XCTestCase {
     }
 
     let q = p
-      .flatMapError { Promise<Int, String>(value: $0.code + 1) }
+      .flatMapError { Promise<Int, NSError>(value: $0.code + 1) }
       .then { _ in
         calls += 1
       }
@@ -89,7 +89,7 @@ class MultipleErrorTests: XCTestCase {
     }
 
     let q = p
-      .flatMapError { Promise<Int, String>(error: "\($0.code + 1)")  }
+      .flatMapError { Promise<Int, NSError>(error: NSError(code: $0.code + 1))  }
       .trap { _ in
         calls += 1
       }

--- a/Tests/PromissumTests/SourceErrorTests.swift
+++ b/Tests/PromissumTests/SourceErrorTests.swift
@@ -47,10 +47,10 @@ class SourceErrorTests: XCTestCase {
 
     let source = PromiseSource<Int, NSError>()
     let p = source.promise
-      .mapError { $0.code + 1 }
+      .mapError { NSError(code: $0.code + 1) }
 
     p.trap { x in
-      value = x
+      value = x.code
     }
 
     source.reject(NSError(domain: PromissumErrorDomain, code: 42, userInfo: nil))
@@ -65,7 +65,7 @@ class SourceErrorTests: XCTestCase {
 
     let source = PromiseSource<Int, NSError>()
     let p = source.promise
-      .flatMapError { Promise<Int, String>(value: $0.code + 1) }
+      .flatMapError { Promise<Int, NSError>(value: $0.code + 1) }
 
     p.then { x in
       value = x

--- a/Tests/PromissumTests/SourceResultTests.swift
+++ b/Tests/PromissumTests/SourceResultTests.swift
@@ -68,11 +68,11 @@ class SourceResultTests: XCTestCase {
     let p: Promise<Int, NoError> = source.promise
       .mapResult { result in
         switch result {
-        case .error(let error):
-          return .value(error.code + 1)
+        case .failure(let error):
+          return .success(error.code + 1)
 
-        case .value:
-          return .value(-1)
+        case .success:
+          return .success(-1)
         }
       }
 
@@ -95,11 +95,11 @@ class SourceResultTests: XCTestCase {
     let p: Promise<Int, NoError> = source.promise
       .mapResult { result in
         switch result {
-        case .value(let value):
-          return .value(value + 1)
+        case .success(let value):
+          return .success(value + 1)
 
-        case .error:
-          return .value(-1)
+        case .failure:
+          return .success(-1)
         }
     }
 
@@ -121,9 +121,9 @@ class SourceResultTests: XCTestCase {
     let p: Promise<Int, NSError> = source.promise
       .flatMapResult { result in
         switch result {
-        case .value(let value):
+        case .success(let value):
           return Promise(value: value + 1)
-        case .error:
+        case .failure:
           return Promise(value: -1)
         }
     }
@@ -146,9 +146,9 @@ class SourceResultTests: XCTestCase {
     let p: Promise<Int, NSError> = source.promise
       .flatMapResult { result in
         switch result {
-        case .value(let value):
+        case .success(let value):
           return Promise(error: NSError(domain: PromissumErrorDomain, code: value + 1, userInfo: nil))
-        case .error:
+        case .failure:
           return Promise(value: -1)
         }
     }
@@ -171,9 +171,9 @@ class SourceResultTests: XCTestCase {
     let p: Promise<Int, NSError> = source.promise
       .flatMapResult { result in
         switch result {
-        case .error(let error):
+        case .failure(let error):
           return Promise(value: error.code + 1)
-        case .value:
+        case .success:
           return Promise(value: -1)
         }
     }
@@ -196,9 +196,9 @@ class SourceResultTests: XCTestCase {
     let p: Promise<Int, NSError> = source.promise
       .flatMapResult { result in
         switch result {
-        case .error(let error):
+        case .failure(let error):
           return Promise(error: NSError(domain: PromissumErrorDomain, code: error.code + 1, userInfo: nil))
-        case .value:
+        case .success:
           return Promise(value: -1)
         }
     }


### PR DESCRIPTION
Replaces Promissum's result type with the one defined by Swift itself. The enum cases are now called `success` and `failure`, and as far as I know there is no way for users of the library to migrate to this automatically. Using `@available()` doesn't seem to be an option because we don't own the Result enum anymore.