### PR TITLE
Deprecate `NoError` in favor of the `Never` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ However, it's easy to change the dispatch queue used by a promise. In one of two
 
 ```swift
 let background = DispatchQueue.global(qos: .background)
-let source = PromiseSource<Int, NoError>(dispatch: .queue(background))
+let source = PromiseSource<Int, Never>(dispatch: .queue(background))
 source.promise
   .then { x in
     // Handler is called on background queue

--- a/Sources/Promissum/Combinators.swift
+++ b/Sources/Promissum/Combinators.swift
@@ -117,8 +117,8 @@ public func whenAny<Value, Error>(_ promises: [Promise<Value, Error>]) -> Promis
 /// Creates a Promise that resolves when all provided Promises finalize.
 ///
 /// When called with an empty array of promises, this returns a Resolved Promise.
-public func whenAllFinalized<Value, Error>(_ promises: [Promise<Value, Error>]) -> Promise<Void, NoError> {
-  let source = PromiseSource<Void, NoError>()
+public func whenAllFinalized<Value, Error>(_ promises: [Promise<Value, Error>]) -> Promise<Void, Never> {
+  let source = PromiseSource<Void, Never>()
   var remaining = promises.count
 
   if remaining == 0 {
@@ -144,8 +144,8 @@ public func whenAllFinalized<Value, Error>(_ promises: [Promise<Value, Error>]) 
 /// Creates a Promise that resolves when any of the provided Promises finalize.
 ///
 /// When called with an empty array of promises, this returns a Promise that will never resolve.
-public func whenAnyFinalized<Value, Error>(_ promises: [Promise<Value, Error>]) -> Promise<Void, NoError> {
-  let source = PromiseSource<Void, NoError>()
+public func whenAnyFinalized<Value, Error>(_ promises: [Promise<Value, Error>]) -> Promise<Void, Never> {
+  let source = PromiseSource<Void, Never>()
 
   for promise in promises {
 

--- a/Sources/Promissum/Promise.swift
+++ b/Sources/Promissum/Promise.swift
@@ -63,7 +63,7 @@ The full type `Promise<Value, Error>` has two type arguments, for both the value
 For example; the type `Promise<String, NSError>` represents a future value of type `String` that can potentially fail with a `NSError`.
 When creating a Promise yourself, it is recommended to use a custom enum to represent the possible errors cases.
 
-In cases where an error is not applicable, you can use the `NoError` type.
+In cases where an error is not applicable, you can use the `Never` type.
 
 
 ## Transforming a Promise value
@@ -73,8 +73,8 @@ Similar to `Array`, a Promise has a `map` method to apply a transform the value 
 In this example an age (Promise of int) is transformed to a future isAdult boolean:
 
 ```
-// agePromise has type Promise<Int, NoError>
-// isAdultPromise has type Promise<Bool, NoError>
+// agePromise has type Promise<Int, Never>
+// isAdultPromise has type Promise<Bool, Never>
 let isAdultPromise = agePromise.map { age in age >= 18 }
 
 ```
@@ -97,7 +97,7 @@ public class Promise<Value, Error> {
 
   /// Initialize a resolved Promise with a value.
   ///
-  /// Example: `Promise<Int, NoError>(value: 42)`
+  /// Example: `Promise<Int, Never>(value: 42)`
   public init(value: Value) {
     self.source = PromiseSource(value: value)
   }

--- a/Sources/Promissum/State.swift
+++ b/Sources/Promissum/State.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// Type used when there is no error possible.
+@available(*, deprecated, renamed: "Never", message: "Use the Never type instead")
 public enum NoError : Error {}
 
 /// State of a PromiseSource.

--- a/Tests/PromissumTests/SourceResultTests.swift
+++ b/Tests/PromissumTests/SourceResultTests.swift
@@ -65,7 +65,7 @@ class SourceResultTests: XCTestCase {
     var value: Int?
 
     let source = PromiseSource<Int, NSError>()
-    let p: Promise<Int, NoError> = source.promise
+    let p: Promise<Int, Never> = source.promise
       .mapResult { result in
         switch result {
         case .error(let error):
@@ -92,7 +92,7 @@ class SourceResultTests: XCTestCase {
     var value: Int?
 
     let source = PromiseSource<Int, NSError>()
-    let p: Promise<Int, NoError> = source.promise
+    let p: Promise<Int, Never> = source.promise
       .mapResult { result in
         switch result {
         case .value(let value):

--- a/examples/MacExample/MacExample/NSAnimationContext+Promise.swift
+++ b/examples/MacExample/MacExample/NSAnimationContext+Promise.swift
@@ -11,8 +11,8 @@ import Promissum
 
 extension NSAnimationContext {
 
-  public class func runAnimationGroupPromise(_ changes: (NSAnimationContext) -> Void) -> Promise<Void, NoError> {
-    let source = PromiseSource<Void, NoError>()
+  public class func runAnimationGroupPromise(_ changes: (NSAnimationContext) -> Void) -> Promise<Void, Never> {
+    let source = PromiseSource<Void, Never>()
 
     self.runAnimationGroup(changes, completionHandler: { source.resolve() })
 

--- a/extensions/PromissumExtensions/AVFoundation+Promise.swift
+++ b/extensions/PromissumExtensions/AVFoundation+Promise.swift
@@ -10,8 +10,8 @@ import AVFoundation
 
 
 extension AVCaptureDevice {
-  public static func requestAccess(forMediaType mediaType: String) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public static func requestAccess(forMediaType mediaType: String) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     AVCaptureDevice.requestAccess(for: AVMediaType(rawValue: mediaType)) { granted in
       source.resolve(granted)

--- a/extensions/PromissumExtensions/UIKit+Promise.swift
+++ b/extensions/PromissumExtensions/UIKit+Promise.swift
@@ -9,48 +9,48 @@
 import UIKit
 
 extension UIView {
-  public class func animatePromise(withDuration duration: TimeInterval, animations: @escaping () -> Void) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public class func animatePromise(withDuration duration: TimeInterval, animations: @escaping () -> Void) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.animate(withDuration: duration, animations: animations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func animate(withDuration duration: TimeInterval, delay: TimeInterval, options: UIView.AnimationOptions, animations: @escaping () -> Void) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public class func animate(withDuration duration: TimeInterval, delay: TimeInterval, options: UIView.AnimationOptions, animations: @escaping () -> Void) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.animate(withDuration: duration, delay: delay, options: options, animations: animations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func transition(with view: UIView, duration: TimeInterval, options: UIView.AnimationOptions, animations: @escaping () -> Void) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public class func transition(with view: UIView, duration: TimeInterval, options: UIView.AnimationOptions, animations: @escaping () -> Void) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.transition(with: view, duration: duration, options: options, animations: animations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func transition(from fromView: UIView, to toView: UIView, duration: TimeInterval, options: UIView.AnimationOptions) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public class func transition(from fromView: UIView, to toView: UIView, duration: TimeInterval, options: UIView.AnimationOptions) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.transition(from: fromView, to: toView, duration: duration, options: options, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func perform(_ animation: UIView.SystemAnimation, onViews views: [UIView], options: UIView.AnimationOptions, animations parallelAnimations: (() -> Void)?) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public class func perform(_ animation: UIView.SystemAnimation, onViews views: [UIView], options: UIView.AnimationOptions, animations parallelAnimations: (() -> Void)?) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.perform(animation, on: views, options: options, animations: parallelAnimations, completion: source.resolve)
 
     return source.promise
   }
 
-  public class func animateKeyframes(withDuration duration: TimeInterval, delay: TimeInterval, options: UIView.KeyframeAnimationOptions, animations: @escaping () -> Void) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public class func animateKeyframes(withDuration duration: TimeInterval, delay: TimeInterval, options: UIView.KeyframeAnimationOptions, animations: @escaping () -> Void) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.animateKeyframes(withDuration: duration, delay: delay, options: options, animations: animations, completion: source.resolve)
 
@@ -59,24 +59,24 @@ extension UIView {
 }
 
 extension UIViewController {
-  public func present(_ viewControllerToPresent: UIViewController, animated flag: Bool) -> Promise<Void, NoError> {
-    let source = PromiseSource<Void, NoError>()
+  public func present(_ viewControllerToPresent: UIViewController, animated flag: Bool) -> Promise<Void, Never> {
+    let source = PromiseSource<Void, Never>()
 
     self.present(viewControllerToPresent, animated: flag, completion: { source.resolve() })
 
     return source.promise
   }
 
-  public func dismiss(animated flag: Bool) -> Promise<Void, NoError> {
-    let source = PromiseSource<Void, NoError>()
+  public func dismiss(animated flag: Bool) -> Promise<Void, Never> {
+    let source = PromiseSource<Void, Never>()
 
     self.dismiss(animated: flag, completion: { source.resolve() })
 
     return source.promise
   }
 
-  public func transition(from fromViewController: UIViewController, to toViewController: UIViewController, duration: TimeInterval, options: UIView.AnimationOptions, animations: (() -> Void)?) -> Promise<Bool, NoError> {
-    let source = PromiseSource<Bool, NoError>()
+  public func transition(from fromViewController: UIViewController, to toViewController: UIViewController, duration: TimeInterval, options: UIView.AnimationOptions, animations: (() -> Void)?) -> Promise<Bool, Never> {
+    let source = PromiseSource<Bool, Never>()
 
     self.transition(from: fromViewController, to: toViewController, duration: duration, options: options, animations: animations, completion: source.resolve)
 
@@ -99,8 +99,8 @@ extension UIAlertView {
     }
   }
 
-  public func showPromise() -> Promise<Int, NoError> {
-    let source = PromiseSource<Int, NoError>()
+  public func showPromise() -> Promise<Int, Never> {
+    let source = PromiseSource<Int, Never>()
     let originalDelegate = self.delegate as? UIAlertViewDelegate
     let delegate = AlertViewDelegate(source: source, alertView: self, originalDelegate: originalDelegate)
 
@@ -112,11 +112,11 @@ extension UIAlertView {
   }
 
   internal class AlertViewDelegate: NSObject, UIAlertViewDelegate {
-    let source: PromiseSource<Int, NoError>
+    let source: PromiseSource<Int, Never>
     let alertView: UIAlertView
     let originalDelegate: UIAlertViewDelegate?
 
-    init(source: PromiseSource<Int, NoError>, alertView: UIAlertView, originalDelegate: UIAlertViewDelegate?) {
+    init(source: PromiseSource<Int, Never>, alertView: UIAlertView, originalDelegate: UIAlertViewDelegate?) {
       self.source = source
       self.alertView = alertView
       self.originalDelegate = originalDelegate
@@ -169,8 +169,8 @@ extension UIActionSheet {
     }
   }
 
-  public func showPromise(in view: UIView) -> Promise<Int, NoError> {
-    let source = PromiseSource<Int, NoError>()
+  public func showPromise(in view: UIView) -> Promise<Int, Never> {
+    let source = PromiseSource<Int, Never>()
     let originalDelegate = self.delegate
     let delegate = ActionSheetDelegate(source: source, actionSheet: self, originalDelegate: originalDelegate)
 
@@ -182,11 +182,11 @@ extension UIActionSheet {
   }
 
   internal class ActionSheetDelegate: NSObject, UIActionSheetDelegate {
-    let source: PromiseSource<Int, NoError>
+    let source: PromiseSource<Int, Never>
     let actionSheet: UIActionSheet
     let originalDelegate: UIActionSheetDelegate?
 
-    init(source: PromiseSource<Int, NoError>, actionSheet: UIActionSheet, originalDelegate: UIActionSheetDelegate?) {
+    init(source: PromiseSource<Int, Never>, actionSheet: UIActionSheet, originalDelegate: UIActionSheetDelegate?) {
       self.source = source
       self.actionSheet = actionSheet
       self.originalDelegate = originalDelegate


### PR DESCRIPTION
This adds an `@available(renamed)` annotation so that Xcode can apply the fix-up.