### PR TITLE
Remove APPLICATION_EXTENSION_API_ONLY declaration

### DIFF
--- a/Promissum.podspec
+++ b/Promissum.podspec
@@ -17,8 +17,6 @@ Promissum really shines when used to combine asynchronous operations from differ
   s.social_media_url  = "https://twitter.com/tomlokhorst"
   s.homepage          = "https://github.com/tomlokhorst/Promissum"
 
-  s.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
-
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
Avoid declaring `APPLICATION_EXTENSION_API_ONLY` when this is not the case (ie when using with Alamofire). CocoaPods will apply `APPLICATION_EXTENSION_API_ONLY` automatically if the target requires it.

Fixes issue #40.