### PR TITLE
Update availability checks for Xcode 13.2

### DIFF
--- a/Sources/Promissum/AsyncExtensions.swift
+++ b/Sources/Promissum/AsyncExtensions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Promise {
 
   /// Async property that returns the value of the promise when it is resolved, or throws when the promise is rejected.
@@ -41,7 +41,7 @@ extension Promise {
   }
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Promise where Error == Swift.Error {
 
   /// Initialize a Promise using an async closure that can throw an error.
@@ -72,7 +72,7 @@ extension Promise where Error == Swift.Error {
   }
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Promise where Error == Never {
 
   /// Async property that returns the value of the promise when it is resolved.


### PR DESCRIPTION
From the [Xcode 13.2 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-13_2-release-notes#Swift):
> You can now use Swift Concurrency in applications that deploy to macOS 10.15, iOS 13, tvOS 13, and watchOS 6 or newer. This support includes async/await, actors, global actors, structured concurrency, and the task APIs. (70738378)